### PR TITLE
test: Skip test if can still write even after changing perms.

### DIFF
--- a/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectScriptStrategyCallableTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectScriptStrategyCallableTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.ByteArrayOutputStream;
@@ -72,6 +73,7 @@ public class DetectScriptStrategyCallableTest {
     @Test
     public void testFailureToDownload() {
         assumeTrue(new File(toolsDirectoryPath).setReadOnly(), "Skipping test because we can't modify file permissions.");
+        assumeFalse(new File(toolsDirectoryPath).canWrite(), "Skipping as test can still write. Possibly running as root.");
 
         DetectScriptStrategy detectScriptStrategy = new DetectScriptStrategy(defaultLogger, defaultProxyHelper, OperatingSystemType.determineFromSystem(), toolsDirectoryPath);
 


### PR DESCRIPTION
The POP build for this project (and all others) runs from within a Docker container. Unfortunately, the user used to launch the commands is root. The test changed is failing in the POP build because it isn't actually throwing an exception as root can still write to the directory.

Add a check to ensure we can't write to the directory after running setReadOnly(), and skip the test if we can.

Local output from running within Docker:
```
Test | Duration | Result
-- | -- | --
testFailureToDownload() | - | ignored
```

Local output NOT running within Docker:
```
Test | Duration | Result
-- | -- | --
testFailureToDownload() | 0.986s | passed
```