### PR TITLE
IDTCTJNKNS-218: Update tests so they run in Windows and Linux environments

### DIFF
--- a/src/test/java/com/synopsys/integration/jenkins/detect/service/DetectEnvironmentServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/service/DetectEnvironmentServiceTest.java
@@ -67,9 +67,7 @@ public class DetectEnvironmentServiceTest {
 
         // Populate expected return IntEnvironmentVariables
         expectedIntEnvironmentVariables.putAll(environmentVariables);
-        builderEnvironmentVariables.forEach((key, value) -> {
-            expectedIntEnvironmentVariables.put(key.getKey(), value);
-        });
+        builderEnvironmentVariables.forEach((key, value) -> expectedIntEnvironmentVariables.put(key.getKey(), value));
 
         detectEnvironmentService = new DetectEnvironmentService(jenkinsIntLogger, jenkinsProxyHelper, jenkinsVersionHelperMock, synopsysCredentialsHelper, jenkinsConfigServiceMock, environmentVariables);
     }
@@ -79,7 +77,7 @@ public class DetectEnvironmentServiceTest {
         IntEnvironmentVariables intEnvironmentVariables = detectEnvironmentService.createDetectEnvironment();
 
         assertEquals(expectedIntEnvironmentVariables, intEnvironmentVariables.getVariables());
-        assertTrue(byteArrayOutputStream.toString().contains("Running Synopsys Detect for Jenkins\n"), "Log should contain default message about what it is running.");
+        assertTrue(byteArrayOutputStream.toString().contains("Running Synopsys Detect for Jenkins"), "Log should contain default message about what it is running.");
     }
 
     @Test
@@ -88,7 +86,8 @@ public class DetectEnvironmentServiceTest {
         IntEnvironmentVariables intEnvironmentVariables = detectEnvironmentService.createDetectEnvironment();
 
         assertEquals(expectedIntEnvironmentVariables, intEnvironmentVariables.getVariables());
-        assertTrue(byteArrayOutputStream.toString().contains(String.format("Running Synopsys Detect for Jenkins version: %s\n", expectedJenkinsPluginVersion)), "Log should contain message, with plugin version, about what it is running.");
+        assertTrue(byteArrayOutputStream.toString().contains(String.format("Running Synopsys Detect for Jenkins version: %s", expectedJenkinsPluginVersion)),
+            "Log should contain message, with plugin version, about what it is running.");
     }
 
     @Test

--- a/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectJarStrategyTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectJarStrategyTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Files;
@@ -13,6 +14,7 @@ import java.util.ArrayList;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -29,26 +31,28 @@ import hudson.model.TaskListener;
 import jenkins.security.MasterToSlaveCallable;
 
 public class DetectJarStrategyTest {
-    private static final String detectJarPath = "/test/detect/jar/path/detect.jar";
-    private static final String remoteJdkHome = "/test/java/home/path";
-    private static final String expectedJdkJavaPath = remoteJdkHome + "/bin/java";
-    private static final String expectedPath = "/test/path/env";
+    private static final String JAVA_EXECUTABLE = (SystemUtils.IS_OS_WINDOWS) ? "java.exe" : "java";
+    private static final String REMOTE_JDK_HOME = new File("/test/java/home/path").getAbsolutePath();
+    private static final String REMOTE_JAVA_RELATIVE_PATH = new File("/bin/" + JAVA_EXECUTABLE).getPath();
+    private static final String EXPECTED_PATH = new File("/test/path/env").getAbsolutePath();
+    private static final String DETECT_JAR_PATH = new File("/test/detect/jar/path/detect.jar").getAbsolutePath();
+    private static final String EXPECTED_JAVA_FULL_PATH = new File(REMOTE_JDK_HOME + REMOTE_JAVA_RELATIVE_PATH).getAbsolutePath();
 
     private IntEnvironmentVariables environmentVariables;
     private JenkinsIntLogger logger;
     private ByteArrayOutputStream byteArrayOutputStream;
 
     public static Stream<Arguments> testSetupCallableJavaHomeSource() {
-        return Stream.of(Arguments.of(" ", System.getProperty("user.dir") + "/ /bin/java"),
-            Arguments.of("", "/bin/java"),
+        return Stream.of(Arguments.of(" ", System.getProperty("user.dir") + File.separator + " " + REMOTE_JAVA_RELATIVE_PATH),
+            Arguments.of("", new File(REMOTE_JAVA_RELATIVE_PATH).getAbsolutePath()),
             Arguments.of(null, "java"),
-            Arguments.of(remoteJdkHome, expectedJdkJavaPath));
+            Arguments.of(REMOTE_JDK_HOME, EXPECTED_JAVA_FULL_PATH));
     }
 
     @BeforeEach
     public void setup() {
         environmentVariables = IntEnvironmentVariables.empty();
-        environmentVariables.put("PATH", expectedPath);
+        environmentVariables.put("PATH", EXPECTED_PATH);
 
         TaskListener taskListener = Mockito.mock(TaskListener.class);
         byteArrayOutputStream = new ByteArrayOutputStream();
@@ -59,7 +63,7 @@ public class DetectJarStrategyTest {
 
     @Test
     public void testArgumentEscaper() {
-        DetectJarStrategy detectJarStrategy = new DetectJarStrategy(logger, environmentVariables, remoteJdkHome, detectJarPath);
+        DetectJarStrategy detectJarStrategy = new DetectJarStrategy(logger, environmentVariables, REMOTE_JDK_HOME, DETECT_JAR_PATH);
         assertEquals(Function.identity(), detectJarStrategy.getArgumentEscaper());
     }
 
@@ -80,7 +84,7 @@ public class DetectJarStrategyTest {
     @Test
     public void testSetupCallableWarnLogging() {
         logger.setLogLevel(LogLevel.WARN);
-        this.executeAndValidateSetupCallable(remoteJdkHome, expectedJdkJavaPath);
+        this.executeAndValidateSetupCallable(REMOTE_JDK_HOME, EXPECTED_JAVA_FULL_PATH);
         this.validateLogsNotPresentInfo();
         this.validateLogsNotPresentDebug();
     }
@@ -88,7 +92,7 @@ public class DetectJarStrategyTest {
     @Test
     public void testSetupCallableInfoLogging() {
         logger.setLogLevel(LogLevel.INFO);
-        this.executeAndValidateSetupCallable(remoteJdkHome, expectedJdkJavaPath);
+        this.executeAndValidateSetupCallable(REMOTE_JDK_HOME, EXPECTED_JAVA_FULL_PATH);
         this.validateLogsPresentInfo();
         this.validateLogsNotPresentDebug();
     }
@@ -96,7 +100,7 @@ public class DetectJarStrategyTest {
     @Test
     public void testSetupCallableDebugLogging() {
         logger.setLogLevel(LogLevel.DEBUG);
-        this.executeAndValidateSetupCallable(remoteJdkHome, expectedJdkJavaPath);
+        this.executeAndValidateSetupCallable(REMOTE_JDK_HOME, EXPECTED_JAVA_FULL_PATH);
         this.validateLogsPresentInfo();
         this.validateLogsPresentDebug();
     }
@@ -104,7 +108,7 @@ public class DetectJarStrategyTest {
     @Test
     public void testSetupCallableTraceLogging() {
         logger.setLogLevel(LogLevel.TRACE);
-        this.executeAndValidateSetupCallable(remoteJdkHome, expectedJdkJavaPath);
+        this.executeAndValidateSetupCallable(REMOTE_JDK_HOME, EXPECTED_JAVA_FULL_PATH);
         this.validateLogsPresentInfo();
         this.validateLogsPresentDebug();
     }
@@ -114,7 +118,7 @@ public class DetectJarStrategyTest {
         logger.setLogLevel(LogLevel.DEBUG);
         try {
             String badJavaHome = Files.createTempDirectory(null).toRealPath().toString();
-            String expectedBadJavaPath = badJavaHome + "/bin/java";
+            String expectedBadJavaPath = badJavaHome + REMOTE_JAVA_RELATIVE_PATH;
             this.executeAndValidateSetupCallable(badJavaHome, expectedBadJavaPath);
 
             assertTrue(byteArrayOutputStream.toString().contains("Error printing the JAVA version: "), "Log does not contain error for printing Java version.");
@@ -128,18 +132,18 @@ public class DetectJarStrategyTest {
         logger.setLogLevel(LogLevel.DEBUG);
         this.executeAndValidateSetupCallable(null, "java");
 
-        assertTrue(byteArrayOutputStream.toString().contains("Java version: \n"), "Log does not contain entry for Java Version heading.");
+        assertTrue(byteArrayOutputStream.toString().contains("Java version: "), "Log does not contain entry for Java Version heading.");
     }
 
     private void executeAndValidateSetupCallable(String javaHomeInput, String expectedJavaPath) {
         try {
-            DetectJarStrategy detectJarStrategy = new DetectJarStrategy(logger, environmentVariables, javaHomeInput, detectJarPath);
+            DetectJarStrategy detectJarStrategy = new DetectJarStrategy(logger, environmentVariables, javaHomeInput, DETECT_JAR_PATH);
             MasterToSlaveCallable<ArrayList<String>, IntegrationException> setupCallable = detectJarStrategy.getSetupCallable();
 
             ArrayList<String> jarExecutionElements = setupCallable.call();
             assertEquals(expectedJavaPath, jarExecutionElements.get(0));
             assertEquals("-jar", jarExecutionElements.get(1));
-            assertEquals(detectJarPath, jarExecutionElements.get(2));
+            assertEquals(DETECT_JAR_PATH, jarExecutionElements.get(2));
         } catch (IntegrationException e) {
             fail("An unexpected exception occurred: ", e);
         }


### PR DESCRIPTION
Update tests to run in Windows and Linux. These edits were run locally (Mac), run on Windows using VirtualBox, and results pushed into Sonar with no new Sonar bugs or code smells.