### PR TITLE
IDTCTJNKNS-233 - Update for Detect 7.x support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'com.blackducksoftware.integration'
-version = '3.1.1-SNAPSHOT'
+version = '7.0.0-SNAPSHOT'
 description = 'Synopsys Detect Plugin for Jenkins'
 
 apply plugin: 'com.synopsys.integration.solution'

--- a/src/main/java/com/synopsys/integration/jenkins/detect/extensions/global/DetectGlobalConfig.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/extensions/global/DetectGlobalConfig.java
@@ -55,7 +55,6 @@ import com.synopsys.integration.jenkins.wrapper.SynopsysCredentialsHelper;
 import com.synopsys.integration.log.LogLevel;
 import com.synopsys.integration.log.PrintStreamIntLogger;
 import com.synopsys.integration.rest.client.ConnectionResult;
-import com.synopsys.integration.rest.credentials.Credentials;
 import com.synopsys.integration.rest.proxy.ProxyInfo;
 
 import hudson.Extension;
@@ -302,24 +301,17 @@ public class DetectGlobalConfig extends GlobalConfiguration implements Serializa
         return getNodeValue(doc, tagName).map(Boolean::valueOf);
     }
 
-    private BlackDuckServerConfigBuilder createBlackDuckServerConfigBuilder(JenkinsProxyHelper jenkinsProxyHelper, SynopsysCredentialsHelper synopsysCredentialsHelper, String blackDuckUrl, String credentialsId, int timeout,
-        boolean alwaysTrust) {
+    private BlackDuckServerConfigBuilder createBlackDuckServerConfigBuilder(JenkinsProxyHelper jenkinsProxyHelper, SynopsysCredentialsHelper synopsysCredentialsHelper,
+        String blackDuckUrl, String credentialsId, int timeout, boolean alwaysTrust) {
         ProxyInfo proxyInfo = jenkinsProxyHelper.getProxyInfo(blackDuckUrl);
+        String apiToken = synopsysCredentialsHelper.getApiTokenByCredentialsId(credentialsId).orElse(null);
 
-        BlackDuckServerConfigBuilder builder = BlackDuckServerConfig.newBuilder()
-                                                   .setUrl(blackDuckUrl)
-                                                   .setTimeoutInSeconds(timeout)
-                                                   .setTrustCert(alwaysTrust)
-                                                   .setProxyInfo(proxyInfo);
-
-        Credentials usernamePasswordCredentials = synopsysCredentialsHelper.getIntegrationCredentialsById(credentialsId);
-        if (!usernamePasswordCredentials.isBlank()) {
-            builder.setCredentials(usernamePasswordCredentials);
-        } else {
-            synopsysCredentialsHelper.getApiTokenByCredentialsId(credentialsId).ifPresent(builder::setApiToken);
-        }
-
-        return builder;
+        return BlackDuckServerConfig.newBuilder()
+                   .setUrl(blackDuckUrl)
+                   .setTimeoutInSeconds(timeout)
+                   .setTrustCert(alwaysTrust)
+                   .setProxyInfo(proxyInfo)
+                   .setApiToken(apiToken);
     }
 
 }

--- a/src/main/java/com/synopsys/integration/jenkins/detect/extensions/global/DetectGlobalConfig.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/extensions/global/DetectGlobalConfig.java
@@ -169,7 +169,7 @@ public class DetectGlobalConfig extends GlobalConfiguration implements Serializa
         jenkins.checkPermission(Jenkins.ADMINISTER);
         return new StandardListBoxModel()
                    .includeEmptyValue()
-                   .includeMatchingAs(ACL.SYSTEM, jenkins, BaseStandardCredentials.class, Collections.emptyList(), SynopsysCredentialsHelper.API_TOKEN_OR_USERNAME_PASSWORD_CREDENTIALS);
+                   .includeMatchingAs(ACL.SYSTEM, jenkins, BaseStandardCredentials.class, Collections.emptyList(), SynopsysCredentialsHelper.API_TOKEN_CREDENTIALS);
     }
 
     @POST

--- a/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectEnvironmentService.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectEnvironmentService.java
@@ -72,12 +72,13 @@ public class DetectEnvironmentService {
     }
 
     private void updateAndFilterVariables(BiConsumer<String, String> environmentPutter, String key, String value) {
-        if ("BLACKDUCK_TIMEOUT".equals(key)) {
-            key = TIMEOUT;
+        String filteredKey = key;
+        if (BlackDuckServerConfigBuilder.TIMEOUT_KEY.getKey().equals(filteredKey)) {
+            filteredKey = TIMEOUT;
         }
 
-        if (StringUtils.isNoneBlank(key, value)) {
-            environmentPutter.accept(key, value);
+        if (StringUtils.isNoneBlank(filteredKey, value)) {
+            environmentPutter.accept(filteredKey, value);
         }
     }
 

--- a/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectEnvironmentService.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectEnvironmentService.java
@@ -72,10 +72,7 @@ public class DetectEnvironmentService {
     }
 
     private void updateAndFilterVariables(BiConsumer<String, String> environmentPutter, String key, String value) {
-        String filteredKey = key;
-        if (BlackDuckServerConfigBuilder.TIMEOUT_KEY.getKey().equals(filteredKey)) {
-            filteredKey = TIMEOUT;
-        }
+        String filteredKey = BlackDuckServerConfigBuilder.TIMEOUT_KEY.getKey().equals(key) ? TIMEOUT : key;
 
         if (StringUtils.isNoneBlank(filteredKey, value)) {
             environmentPutter.accept(filteredKey, value);

--- a/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectEnvironmentService.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectEnvironmentService.java
@@ -23,6 +23,8 @@ import com.synopsys.integration.jenkins.wrapper.SynopsysCredentialsHelper;
 import com.synopsys.integration.util.IntEnvironmentVariables;
 
 public class DetectEnvironmentService {
+    public static final String TIMEOUT = "DETECT_TIMEOUT";
+
     private final JenkinsIntLogger logger;
     private final JenkinsProxyHelper jenkinsProxyHelper;
     private final JenkinsVersionHelper jenkinsVersionHelper;
@@ -66,10 +68,14 @@ public class DetectEnvironmentService {
         BlackDuckServerConfigBuilder blackDuckServerConfigBuilder = detectGlobalConfig.get().getBlackDuckServerConfigBuilder(jenkinsProxyHelper, synopsysCredentialsHelper);
 
         blackDuckServerConfigBuilder.getProperties()
-            .forEach((builderPropertyKey, propertyValue) -> acceptIfNotNull(environmentPutter, builderPropertyKey.getKey(), propertyValue));
+            .forEach((builderPropertyKey, propertyValue) -> updateAndFilterVariables(environmentPutter, builderPropertyKey.getKey(), propertyValue));
     }
 
-    private void acceptIfNotNull(BiConsumer<String, String> environmentPutter, String key, String value) {
+    private void updateAndFilterVariables(BiConsumer<String, String> environmentPutter, String key, String value) {
+        if ("BLACKDUCK_TIMEOUT".equals(key)) {
+            key = TIMEOUT;
+        }
+
         if (StringUtils.isNoneBlank(key, value)) {
             environmentPutter.accept(key, value);
         }

--- a/src/main/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectScriptStrategy.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectScriptStrategy.java
@@ -34,9 +34,9 @@ import jenkins.security.MasterToSlaveCallable;
 
 public class DetectScriptStrategy extends DetectExecutionStrategy {
     public static final String DETECT_INSTALL_DIRECTORY = "Detect_Installation";
-    public static final String LATEST_SHELL_SCRIPT_URL = "https://detect.synopsys.com/detect.sh";
+    public static final String LATEST_SHELL_SCRIPT_URL = "https://detect.synopsys.com/detect7.sh";
     public static final String SHELL_SCRIPT_FILENAME = "detect.sh";
-    public static final String LATEST_POWERSHELL_SCRIPT_URL = "https://detect.synopsys.com/detect.ps1";
+    public static final String LATEST_POWERSHELL_SCRIPT_URL = "https://detect.synopsys.com/detect7.ps1";
     public static final String POWERSHELL_SCRIPT_FILENAME = "detect.ps1";
 
     private final JenkinsIntLogger logger;

--- a/src/test/java/com/synopsys/integration/jenkins/detect/DetectRunnerTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/DetectRunnerTest.java
@@ -40,7 +40,7 @@ import com.synopsys.integration.util.IntEnvironmentVariables;
 import com.synopsys.integration.util.OperatingSystemType;
 
 public class DetectRunnerTest {
-    private static final String DETECT_PROPERTY_INPUT = "--detect.docker.passthrough.service.timeout=$BLACKDUCK_TIMEOUT --detect.cleanup=false --detect.project.name=\"Test Project'\"";
+    private static final String DETECT_PROPERTY_INPUT = "--detect.docker.passthrough.service.timeout=$DETECT_TIMEOUT --detect.cleanup=false --detect.project.name=\"Test Project'\"";
     private static final String WORKSPACE_TMP_REL_PATH = "out/test/DetectPostBuildStepTest/testPerform/workspace@tmp";
     private static final String JDK_HOME = "/tmp/jdk/bin/java";
     private static final String DETECT_JAR_PATH = "/tmp/detect.jar";

--- a/src/test/java/com/synopsys/integration/jenkins/detect/service/DetectEnvironmentServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/service/DetectEnvironmentServiceTest.java
@@ -1,11 +1,11 @@
 package com.synopsys.integration.jenkins.detect.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import com.synopsys.integration.blackduck.configuration.BlackDuckServerConfig;
 import com.synopsys.integration.blackduck.configuration.BlackDuckServerConfigBuilder;
-import com.synopsys.integration.builder.BuilderPropertyKey;
 import com.synopsys.integration.jenkins.detect.extensions.global.DetectGlobalConfig;
 import com.synopsys.integration.jenkins.extensions.JenkinsIntLogger;
 import com.synopsys.integration.jenkins.service.JenkinsConfigService;
@@ -28,83 +28,91 @@ import com.synopsys.integration.util.IntEnvironmentVariables;
 import hudson.model.TaskListener;
 
 public class DetectEnvironmentServiceTest {
-    private final static String expectedJenkinsPluginVersion = "JenkinsPluginVersion";
-
     private final TaskListener taskListenerMock = Mockito.mock(TaskListener.class);
     private final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     private final JenkinsIntLogger jenkinsIntLogger = new JenkinsIntLogger(taskListenerMock);
 
-    private final JenkinsProxyHelper jenkinsProxyHelper = new JenkinsProxyHelper("proxyHost", 31339, "proxyUsername", "proxyPassword", Collections.emptyList(), "ntlmDomain", "ntlmWorkstation");
-    private final JenkinsVersionHelper jenkinsVersionHelperMock = Mockito.mock(JenkinsVersionHelper.class);
+    public final BlackDuckServerConfigBuilder blackDuckServerConfigBuilder = BlackDuckServerConfig.newBuilder().setTimeoutInSeconds(120);
+
+    private final String junitKey = "__JUNIT_KEY__";
+    private final String junitValue = "__JUNIT_VALUE__";
+
     private final JenkinsWrapper jenkinsWrapper = JenkinsWrapper.initializeFromJenkinsJVM();
     private final SynopsysCredentialsHelper synopsysCredentialsHelper = new SynopsysCredentialsHelper(jenkinsWrapper);
-    private final JenkinsConfigService jenkinsConfigServiceMock = Mockito.mock(JenkinsConfigService.class);
+    private final JenkinsProxyHelper jenkinsProxyHelper = new JenkinsProxyHelper();
+
     private final DetectGlobalConfig detectGlobalConfig = Mockito.mock(DetectGlobalConfig.class);
-    private final BlackDuckServerConfigBuilder blackDuckServerConfigBuilderMock = Mockito.mock(BlackDuckServerConfigBuilder.class);
+    private final JenkinsConfigService jenkinsConfigServiceMock = Mockito.mock(JenkinsConfigService.class);
+    private final JenkinsVersionHelper jenkinsVersionHelperMock = Mockito.mock(JenkinsVersionHelper.class);
 
     private DetectEnvironmentService detectEnvironmentService;
 
-    private Map<String, String> environmentVariables = new HashMap<>();
-    private Map<BuilderPropertyKey, String> builderEnvironmentVariables = new HashMap<>();
-    private Map<String, String> expectedIntEnvironmentVariables = new HashMap<>();
-
     @BeforeEach
     public void setUp() {
-        // Populate input environment variables passed to constructor
-        for (int i = 1; i <= 5; i++) {
-            environmentVariables.put("env_key_" + i, "env_value_" + i);
-        }
-        environmentVariables.put("BLACK_DUCK_LOG_LEVEL", "DEBUG");
-
-        // Populate builder environment variables used as a return for mocking
-        builderEnvironmentVariables.put(BlackDuckServerConfigBuilder.TIMEOUT_KEY, "120");
-
-        // Setup mocked data
         Mockito.when(taskListenerMock.getLogger()).thenReturn(new PrintStream(byteArrayOutputStream));
         Mockito.when(jenkinsConfigServiceMock.getGlobalConfiguration(DetectGlobalConfig.class)).thenReturn(Optional.of(detectGlobalConfig));
-        Mockito.when(detectGlobalConfig.getBlackDuckServerConfigBuilder(jenkinsProxyHelper, synopsysCredentialsHelper)).thenReturn(blackDuckServerConfigBuilderMock);
-        Mockito.when(blackDuckServerConfigBuilderMock.getProperties()).thenReturn(builderEnvironmentVariables);
+        Mockito.when(detectGlobalConfig.getBlackDuckServerConfigBuilder(jenkinsProxyHelper, synopsysCredentialsHelper)).thenReturn(blackDuckServerConfigBuilder);
 
-        // Populate expected return IntEnvironmentVariables
-        expectedIntEnvironmentVariables.putAll(environmentVariables);
-        builderEnvironmentVariables.forEach((key, value) -> expectedIntEnvironmentVariables.put(key.getKey(), value));
-
-        detectEnvironmentService = new DetectEnvironmentService(jenkinsIntLogger, jenkinsProxyHelper, jenkinsVersionHelperMock, synopsysCredentialsHelper, jenkinsConfigServiceMock, environmentVariables);
+        detectEnvironmentService = new DetectEnvironmentService(jenkinsIntLogger, jenkinsProxyHelper, jenkinsVersionHelperMock, synopsysCredentialsHelper, jenkinsConfigServiceMock, new HashMap<>());
     }
 
     @Test
     public void testNoPluginVersionInLog() {
-        IntEnvironmentVariables intEnvironmentVariables = detectEnvironmentService.createDetectEnvironment();
-
-        assertEquals(expectedIntEnvironmentVariables, intEnvironmentVariables.getVariables());
-        assertTrue(byteArrayOutputStream.toString().contains("Running Synopsys Detect for Jenkins"), "Log should contain default message about what it is running.");
+        detectEnvironmentService.createDetectEnvironment();
+        assertTrue(byteArrayOutputStream.toString().contains("Running Synopsys Detect for Jenkins"), "Log should contain default message");
     }
 
     @Test
     public void testPluginVersionInLog() {
+        String expectedJenkinsPluginVersion = "JenkinsPluginVersion";
         Mockito.when(jenkinsVersionHelperMock.getPluginVersion("blackduck-detect")).thenReturn(Optional.of(expectedJenkinsPluginVersion));
-        IntEnvironmentVariables intEnvironmentVariables = detectEnvironmentService.createDetectEnvironment();
 
-        assertEquals(expectedIntEnvironmentVariables, intEnvironmentVariables.getVariables());
+        detectEnvironmentService.createDetectEnvironment();
         assertTrue(byteArrayOutputStream.toString().contains(String.format("Running Synopsys Detect for Jenkins version: %s", expectedJenkinsPluginVersion)),
-            "Log should contain message, with plugin version, about what it is running.");
+            "Log should contain message with plugin version");
     }
 
     @Test
-    public void testNullInDetectGlobalConfig() {
-        builderEnvironmentVariables.put(BlackDuckServerConfigBuilder.PASSWORD_KEY, null);
+    public void testNullsInDetectGlobalConfig() {
+        blackDuckServerConfigBuilder.setProperty(junitKey, null);
+        blackDuckServerConfigBuilder.setProperty(null, junitValue);
+        blackDuckServerConfigBuilder.setTimeoutInSeconds(null);
+        assertTrue(blackDuckServerConfigBuilder.getEnvironmentVariableKeys().contains(junitKey), String.format("Should contain key %s", junitKey));
+        assertTrue(blackDuckServerConfigBuilder.getProperties().containsValue(junitValue), String.format("Should contain value %s", junitValue));
+        assertTrue(blackDuckServerConfigBuilder.getProperties().containsKey(BlackDuckServerConfigBuilder.TIMEOUT_KEY), String.format("Should contain %s", BlackDuckServerConfigBuilder.TIMEOUT_KEY));
+
         IntEnvironmentVariables intEnvironmentVariables = detectEnvironmentService.createDetectEnvironment();
-
-        assertEquals(expectedIntEnvironmentVariables, intEnvironmentVariables.getVariables());
+        assertFalse(intEnvironmentVariables.containsKey(junitKey), String.format("Should NOT contain key %s", junitKey));
+        assertFalse(intEnvironmentVariables.getVariables().containsValue(junitValue), String.format("Should contain value %s", junitKey));
+        assertFalse(intEnvironmentVariables.containsKey(DetectEnvironmentService.TIMEOUT), String.format("Should NOT contain %s", BlackDuckServerConfigBuilder.TIMEOUT_KEY));
     }
 
     @Test
-    public void testNoValidDetectGlobalConfig() {
+    public void testEmptyDetectGlobalConfig() {
         Mockito.when(jenkinsConfigServiceMock.getGlobalConfiguration(DetectGlobalConfig.class)).thenReturn(Optional.empty());
         IntEnvironmentVariables intEnvironmentVariables = detectEnvironmentService.createDetectEnvironment();
 
-        // Return should not contain values from builderEnvironmentVariables, so compare against environmentVariables only
-        assertEquals(environmentVariables, intEnvironmentVariables.getVariables());
+        assertTrue(intEnvironmentVariables.getVariables().isEmpty(), "Should be an empty map");
+    }
+
+    @Test
+    public void testEnvironmentAdded() {
+        Map<String, String> environmentVariables = new HashMap<>();
+        environmentVariables.put(junitKey, junitValue);
+        detectEnvironmentService = new DetectEnvironmentService(jenkinsIntLogger, jenkinsProxyHelper, jenkinsVersionHelperMock, synopsysCredentialsHelper, jenkinsConfigServiceMock, environmentVariables);
+        IntEnvironmentVariables intEnvironmentVariables = detectEnvironmentService.createDetectEnvironment();
+
+        assertTrue(intEnvironmentVariables.containsKey(junitKey), String.format("Should contain key %s", junitKey));
+        assertEquals(junitValue, intEnvironmentVariables.getValue(junitKey), String.format("Value should equal %s", junitValue));
+    }
+
+    @Test
+    public void testRenameEnvironmentVariable() {
+        assertTrue(blackDuckServerConfigBuilder.getProperties().containsKey(BlackDuckServerConfigBuilder.TIMEOUT_KEY), String.format("Should contain %s", BlackDuckServerConfigBuilder.TIMEOUT_KEY));
+
+        IntEnvironmentVariables intEnvironmentVariables = detectEnvironmentService.createDetectEnvironment();
+        assertFalse(intEnvironmentVariables.containsKey(BlackDuckServerConfigBuilder.TIMEOUT_KEY.getKey()), String.format("Should NOT contain %s", BlackDuckServerConfigBuilder.TIMEOUT_KEY));
+        assertTrue(intEnvironmentVariables.containsKey(DetectEnvironmentService.TIMEOUT), String.format("Should contain key %s", DetectEnvironmentService.TIMEOUT));
     }
 
 }


### PR DESCRIPTION
Changes for supporting Detect 7.x

* Update version to 7.0.0 to match major version of supported Detect
* Only use getApiTokenByCredentialsId() to get credentials, as user/pass is no longer supported
* Handle change in name of Detect property BLACKDUCK_TIMEOUT --> DETECT_TIMEOUT
* Update URL's to pull Detect 7 scripts
* Update tests for new functionality
* Refactor existing tests within DetectEnvironmentServiceTest for better clarity

Testing was done on local instance of Jenkins for both pipeline and freestyle.