### PR TITLE
Updates to improve/fix logging messages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     annotationProcessor 'com.synopsys.integration:jenkins-annotation-processor:0.0.1'
 
     implementation 'com.synopsys.integration:blackduck-common:49.1.0'
-    implementation 'com.synopsys.integration:jenkins-common:0.3.1'
+    implementation 'com.synopsys.integration:jenkins-common:0.3.2'
     implementation 'org.jvnet.localizer:localizer:1.24'
 
     jenkinsPlugins 'org.jenkins-ci.plugins:credentials:2.1.10'

--- a/build.gradle
+++ b/build.gradle
@@ -36,11 +36,11 @@ jenkinsPlugin {
 }
 
 dependencies {
-    annotationProcessor 'com.synopsys.integration:jenkins-annotation-processor:0.0.1'
+    annotationProcessor 'com.synopsys.integration:jenkins-annotation-processor:0.0.2'
 
-    implementation 'com.synopsys.integration:blackduck-common:49.1.0'
-    implementation 'com.synopsys.integration:jenkins-common:0.3.2'
-    implementation 'org.jvnet.localizer:localizer:1.24'
+    implementation 'com.synopsys.integration:blackduck-common:64.3.2'
+    implementation 'com.synopsys.integration:jenkins-common:0.5.1'
+    implementation 'org.jvnet.localizer:localizer:1.31'
 
     jenkinsPlugins 'org.jenkins-ci.plugins:credentials:2.1.10'
     jenkinsPlugins 'org.jenkins-ci.plugins:plain-credentials:1.0'

--- a/src/main/java/com/synopsys/integration/jenkins/detect/DetectRunner.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/DetectRunner.java
@@ -16,32 +16,64 @@ import com.synopsys.integration.jenkins.detect.service.DetectArgumentService;
 import com.synopsys.integration.jenkins.detect.service.DetectEnvironmentService;
 import com.synopsys.integration.jenkins.detect.service.strategy.DetectExecutionStrategy;
 import com.synopsys.integration.jenkins.detect.service.strategy.DetectStrategyService;
+import com.synopsys.integration.jenkins.extensions.JenkinsIntLogger;
 import com.synopsys.integration.jenkins.service.JenkinsRemotingService;
 import com.synopsys.integration.util.IntEnvironmentVariables;
 import com.synopsys.integration.util.OperatingSystemType;
 
 public class DetectRunner {
+    public static final String ASTERISKS = "******************************************************************************";
+
     private final DetectEnvironmentService detectEnvironmentService;
     private final JenkinsRemotingService remotingService;
     private final DetectStrategyService detectStrategyService;
     private final DetectArgumentService detectArgumentService;
+    private final JenkinsIntLogger logger;
 
-    public DetectRunner(DetectEnvironmentService detectEnvironmentService, JenkinsRemotingService remotingService, DetectStrategyService detectStrategyService, DetectArgumentService detectArgumentService) {
+    public DetectRunner(
+        DetectEnvironmentService detectEnvironmentService,
+        JenkinsRemotingService remotingService,
+        DetectStrategyService detectStrategyService,
+        DetectArgumentService detectArgumentService,
+        JenkinsIntLogger logger
+    ) {
         this.detectEnvironmentService = detectEnvironmentService;
         this.remotingService = remotingService;
         this.detectStrategyService = detectStrategyService;
         this.detectArgumentService = detectArgumentService;
+        this.logger = logger;
     }
 
-    public int runDetect(String remoteJdkHome, String detectArgumentString, DetectDownloadStrategy detectDownloadStrategy) throws IOException, InterruptedException, IntegrationException {
+    public int runDetect(String remoteJdkHome, String detectArgumentString, DetectDownloadStrategy detectDownloadStrategy)
+        throws IOException, InterruptedException, IntegrationException {
         IntEnvironmentVariables intEnvironmentVariables = detectEnvironmentService.createDetectEnvironment();
         OperatingSystemType operatingSystemType = remotingService.getRemoteOperatingSystemType();
-        DetectExecutionStrategy detectExecutionStrategy = detectStrategyService.getExecutionStrategy(intEnvironmentVariables, operatingSystemType, remoteJdkHome, detectDownloadStrategy);
+        DetectExecutionStrategy detectExecutionStrategy = detectStrategyService.getExecutionStrategy(
+            intEnvironmentVariables,
+            operatingSystemType,
+            remoteJdkHome,
+            detectDownloadStrategy
+        );
 
         List<String> initialArguments = remotingService.call(detectExecutionStrategy.getSetupCallable());
 
-        List<String> detectCommands = detectArgumentService.getDetectArguments(intEnvironmentVariables, detectExecutionStrategy.getArgumentEscaper(), initialArguments, detectArgumentString);
+        List<String> detectCommands = detectArgumentService.getDetectArguments(
+            intEnvironmentVariables,
+            detectExecutionStrategy.getArgumentEscaper(),
+            initialArguments,
+            detectArgumentString
+        );
 
-        return remotingService.launch(intEnvironmentVariables, detectCommands);
+        logger.info(ASTERISKS);
+        logger.info("START OF DETECT");
+        logger.info(ASTERISKS);
+
+        int detectRun = remotingService.launch(intEnvironmentVariables, detectCommands);
+
+        logger.info(ASTERISKS);
+        logger.info("END OF DETECT");
+        logger.info(ASTERISKS);
+
+        return detectRun;
     }
 }

--- a/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectCommandsFactory.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectCommandsFactory.java
@@ -91,12 +91,13 @@ public class DetectCommandsFactory {
         return new DetectPipelineCommands(detectCommandsFactory.createDetectRunner(jenkinsConfigService, jenkinsRemotingService), detectCommandsFactory.getLogger());
     }
 
-    private DetectRunner createDetectRunner(JenkinsConfigService jenkinsConfigService, JenkinsRemotingService jenkinsRemotingService) throws AbortException {
+    private DetectRunner createDetectRunner(JenkinsConfigService jenkinsConfigService, JenkinsRemotingService jenkinsRemotingService) {
         return new DetectRunner(
             createDetectEnvironmentService(jenkinsConfigService),
             jenkinsRemotingService,
             createDetectStrategyService(jenkinsConfigService),
-            createDetectArgumentService()
+            createDetectArgumentService(),
+            getLogger()
         );
     }
 

--- a/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectEnvironmentService.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectEnvironmentService.java
@@ -32,8 +32,14 @@ public class DetectEnvironmentService {
     private final Map<String, String> environmentVariables;
     private final JenkinsConfigService jenkinsConfigService;
 
-    public DetectEnvironmentService(JenkinsIntLogger logger, JenkinsProxyHelper jenkinsProxyHelper, JenkinsVersionHelper jenkinsVersionHelper, SynopsysCredentialsHelper synopsysCredentialsHelper, JenkinsConfigService jenkinsConfigService,
-        Map<String, String> environmentVariables) {
+    public DetectEnvironmentService(
+        JenkinsIntLogger logger,
+        JenkinsProxyHelper jenkinsProxyHelper,
+        JenkinsVersionHelper jenkinsVersionHelper,
+        SynopsysCredentialsHelper synopsysCredentialsHelper,
+        JenkinsConfigService jenkinsConfigService,
+        Map<String, String> environmentVariables
+    ) {
         this.logger = logger;
         this.jenkinsProxyHelper = jenkinsProxyHelper;
         this.jenkinsVersionHelper = jenkinsVersionHelper;
@@ -51,9 +57,9 @@ public class DetectEnvironmentService {
 
         Optional<String> pluginVersion = jenkinsVersionHelper.getPluginVersion("blackduck-detect");
         if (pluginVersion.isPresent()) {
-            logger.info("Running Synopsys Detect for Jenkins version: " + pluginVersion.get());
+            logger.info("Running Synopsys Detect Plugin for Jenkins version: " + pluginVersion.get());
         } else {
-            logger.info("Running Synopsys Detect for Jenkins");
+            logger.info("Running Synopsys Detect Plugin for Jenkins");
         }
 
         return intEnvironmentVariables;

--- a/src/main/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectScriptStrategy.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectScriptStrategy.java
@@ -148,7 +148,7 @@ public class DetectScriptStrategy extends DetectExecutionStrategy {
 
                 logger.info(String.format("Downloading Detect script from %s to %s", scriptUrl, detectScriptPath));
 
-                IntHttpClient intHttpClient = new IntHttpClient(logger, gson, 120, true, rebuildProxyInfo());
+                IntHttpClient intHttpClient = new IntHttpClient(logger, gson, 120, false, rebuildProxyInfo());
                 Request request = new Request.Builder().url(new HttpUrl(scriptUrl)).build();
 
                 try (Response response = intHttpClient.execute(request)) {

--- a/src/main/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectStrategyService.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectStrategyService.java
@@ -9,6 +9,7 @@ package com.synopsys.integration.jenkins.detect.service.strategy;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.google.gson.Gson;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.jenkins.detect.DetectJenkinsEnvironmentVariable;
 import com.synopsys.integration.jenkins.detect.exception.DetectJenkinsException;
@@ -35,13 +36,18 @@ public class DetectStrategyService {
         this.jenkinsConfigService = jenkinsConfigService;
     }
 
-    public DetectExecutionStrategy getExecutionStrategy(IntEnvironmentVariables intEnvironmentVariables, OperatingSystemType operatingSystemType, String remoteJdkHome, DetectDownloadStrategy detectDownloadStrategy)
+    public DetectExecutionStrategy getExecutionStrategy(
+        IntEnvironmentVariables intEnvironmentVariables,
+        OperatingSystemType operatingSystemType,
+        String remoteJdkHome,
+        DetectDownloadStrategy detectDownloadStrategy
+    )
         throws IntegrationException {
         String loggingMessage = "Running Detect using configured strategy: ";
 
         if (detectDownloadStrategy == null || detectDownloadStrategy instanceof InheritFromGlobalDownloadStrategy) {
             DetectGlobalConfig detectGlobalConfig = jenkinsConfigService.getGlobalConfiguration(DetectGlobalConfig.class)
-                                                        .orElseThrow(() -> new DetectJenkinsException("Could not find Detect configuration. Check Jenkins System Configuration to ensure Detect is configured correctly."));
+                .orElseThrow(() -> new DetectJenkinsException("Could not find Detect configuration. Check Jenkins System Configuration to ensure Detect is configured correctly."));
             detectDownloadStrategy = detectGlobalConfig.getDownloadStrategy();
 
             if (detectDownloadStrategy == null) {
@@ -58,11 +64,17 @@ public class DetectStrategyService {
         DetectExecutionStrategy detectExecutionStrategy;
 
         if (detectDownloadStrategy instanceof AirGapDownloadStrategy) {
-            detectExecutionStrategy = new DetectAirGapJarStrategy(logger, intEnvironmentVariables, remoteJdkHome, jenkinsConfigService, (AirGapDownloadStrategy) detectDownloadStrategy);
+            detectExecutionStrategy = new DetectAirGapJarStrategy(
+                logger,
+                intEnvironmentVariables,
+                remoteJdkHome,
+                jenkinsConfigService,
+                (AirGapDownloadStrategy) detectDownloadStrategy
+            );
         } else if (StringUtils.isNotBlank(detectJarPath)) {
             detectExecutionStrategy = new DetectJarStrategy(logger, intEnvironmentVariables, remoteJdkHome, detectJarPath);
         } else {
-            detectExecutionStrategy = new DetectScriptStrategy(logger, jenkinsProxyHelper, operatingSystemType, remoteTempWorkspacePath);
+            detectExecutionStrategy = new DetectScriptStrategy(logger, jenkinsProxyHelper, operatingSystemType, remoteTempWorkspacePath, new Gson());
         }
 
         return detectExecutionStrategy;

--- a/src/test/java/com/synopsys/integration/jenkins/detect/DetectRunnerTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/DetectRunnerTest.java
@@ -82,12 +82,12 @@ public class DetectRunnerTest {
         int i = 0;
         assertEquals("bash", actualCommand.get(i++));
         assertEquals(DETECT_SHELL_PATH, actualCommand.get(i++));
-        assertEquals("--detect.docker.passthrough.service.timeout\\=120", actualCommand.get(i++));
-        assertEquals("--detect.cleanup\\=false", actualCommand.get(i++));
-        assertEquals("--detect.project.name\\=Test\\ Project\\'", actualCommand.get(i++));
-        assertEquals("--logging.level.com.synopsys.integration\\=INFO", actualCommand.get(i++));
-        assertTrue(actualCommand.get(i++).startsWith("--detect.phone.home.passthrough.jenkins.version\\="));
-        assertTrue(actualCommand.get(i).startsWith("--detect.phone.home.passthrough.jenkins.plugin.version\\="));
+        assertEquals("--detect.docker.passthrough.service.timeout=120", actualCommand.get(i++));
+        assertEquals("--detect.cleanup=false", actualCommand.get(i++));
+        assertEquals("--detect.project.name=Test\\ Project\\'", actualCommand.get(i++));
+        assertEquals("--logging.level.com.synopsys.integration=INFO", actualCommand.get(i++));
+        assertTrue(actualCommand.get(i++).startsWith("--detect.phone.home.passthrough.jenkins.version="));
+        assertTrue(actualCommand.get(i).startsWith("--detect.phone.home.passthrough.jenkins.plugin.version="));
     }
 
     @Test
@@ -100,12 +100,12 @@ public class DetectRunnerTest {
         int i = 0;
         assertEquals("powershell", actualCommand.get(i++));
         assertEquals("\"Import-Module '" + DETECT_POWERSHELL_PATH + "'; detect\"", actualCommand.get(i++));
-        assertEquals("--detect.docker.passthrough.service.timeout`=120", actualCommand.get(i++));
-        assertEquals("--detect.cleanup`=false", actualCommand.get(i++));
-        assertEquals("--detect.project.name`=Test` Project`'", actualCommand.get(i++));
-        assertEquals("--logging.level.com.synopsys.integration`=INFO", actualCommand.get(i++));
-        assertTrue(actualCommand.get(i++).startsWith("--detect.phone.home.passthrough.jenkins.version`="));
-        assertTrue(actualCommand.get(i).startsWith("--detect.phone.home.passthrough.jenkins.plugin.version`="));
+        assertEquals("--detect.docker.passthrough.service.timeout=120", actualCommand.get(i++));
+        assertEquals("--detect.cleanup=false", actualCommand.get(i++));
+        assertEquals("--detect.project.name=Test` Project`'", actualCommand.get(i++));
+        assertEquals("--logging.level.com.synopsys.integration=INFO", actualCommand.get(i++));
+        assertTrue(actualCommand.get(i++).startsWith("--detect.phone.home.passthrough.jenkins.version="));
+        assertTrue(actualCommand.get(i).startsWith("--detect.phone.home.passthrough.jenkins.plugin.version="));
     }
 
     @Test

--- a/src/test/java/com/synopsys/integration/jenkins/detect/DetectRunnerTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/DetectRunnerTest.java
@@ -133,11 +133,14 @@ public class DetectRunnerTest {
         JenkinsRemotingService mockedRemotingService = Mockito.mock(JenkinsRemotingService.class);
 
         try {
-            Mockito.when(mockedRemotingService.call(Mockito.any(DetectJarStrategy.SetupCallableImpl.class))).thenReturn(new ArrayList<>(Arrays.asList(JDK_HOME, "-jar", detectPath)));
-            Mockito.when(mockedRemotingService.call(Mockito.any(DetectAirGapJarStrategy.SetupCallableImpl.class))).thenReturn(new ArrayList<>(Arrays.asList(JDK_HOME, "-jar", DETECT_AIRGAP_JAR_PATH)));
+            Mockito.when(mockedRemotingService.call(Mockito.any(DetectJarStrategy.SetupCallableImpl.class)))
+                .thenReturn(new ArrayList<>(Arrays.asList(JDK_HOME, "-jar", detectPath)));
+            Mockito.when(mockedRemotingService.call(Mockito.any(DetectAirGapJarStrategy.SetupCallableImpl.class)))
+                .thenReturn(new ArrayList<>(Arrays.asList(JDK_HOME, "-jar", DETECT_AIRGAP_JAR_PATH)));
 
             if (operatingSystemType == OperatingSystemType.WINDOWS) {
-                Mockito.when(mockedRemotingService.call(Mockito.any(DetectScriptStrategy.SetupCallableImpl.class))).thenReturn(new ArrayList<>(Arrays.asList("powershell", String.format("\"Import-Module '%s'; detect\"", detectPath))));
+                Mockito.when(mockedRemotingService.call(Mockito.any(DetectScriptStrategy.SetupCallableImpl.class)))
+                    .thenReturn(new ArrayList<>(Arrays.asList("powershell", String.format("\"Import-Module '%s'; detect\"", detectPath))));
             } else {
                 Mockito.when(mockedRemotingService.call(Mockito.any(DetectScriptStrategy.SetupCallableImpl.class))).thenReturn(new ArrayList<>(Arrays.asList("bash", detectPath)));
             }
@@ -151,9 +154,13 @@ public class DetectRunnerTest {
         return mockedRemotingService;
     }
 
-    private List<String> runDetectAndCaptureCommand(Map<String, String> environmentVariables, JenkinsRemotingService mockedRemotingService, DetectDownloadStrategy detectDownloadStrategy) {
+    private List<String> runDetectAndCaptureCommand(
+        Map<String, String> environmentVariables,
+        JenkinsRemotingService mockedRemotingService,
+        DetectDownloadStrategy detectDownloadStrategy
+    ) {
         try {
-            JenkinsIntLogger jenkinsIntLogger = new JenkinsIntLogger(null);
+            JenkinsIntLogger jenkinsIntLogger = JenkinsIntLogger.logToListener(null);
             Map<BuilderPropertyKey, String> builderEnvironmentVariables = new HashMap<>();
             builderEnvironmentVariables.put(BlackDuckServerConfigBuilder.TIMEOUT_KEY, "120");
 
@@ -168,7 +175,8 @@ public class DetectRunnerTest {
 
             // Mocks specific to AirGap
             DetectAirGapInstallation detectAirGapInstallationMock = Mockito.mock(DetectAirGapInstallation.class);
-            Mockito.when(jenkinsConfigService.getInstallationForNodeAndEnvironment(DetectAirGapInstallation.DescriptorImpl.class, AIRGAP_TOOL_NAME)).thenReturn(Optional.ofNullable(detectAirGapInstallationMock));
+            Mockito.when(jenkinsConfigService.getInstallationForNodeAndEnvironment(DetectAirGapInstallation.DescriptorImpl.class, AIRGAP_TOOL_NAME))
+                .thenReturn(Optional.ofNullable(detectAirGapInstallationMock));
             Mockito.doReturn(AIRGAP_TOOL_PATH).when(detectAirGapInstallationMock).getHome();
 
             JenkinsVersionHelper mockedVersionHelper = Mockito.mock(JenkinsVersionHelper.class);
@@ -177,7 +185,14 @@ public class DetectRunnerTest {
 
             JenkinsProxyHelper blankProxyHelper = new JenkinsProxyHelper();
 
-            DetectEnvironmentService detectEnvironmentService = new DetectEnvironmentService(jenkinsIntLogger, blankProxyHelper, mockedVersionHelper, mockedCredentialsHelper, jenkinsConfigService, environmentVariables);
+            DetectEnvironmentService detectEnvironmentService = new DetectEnvironmentService(
+                jenkinsIntLogger,
+                blankProxyHelper,
+                mockedVersionHelper,
+                mockedCredentialsHelper,
+                jenkinsConfigService,
+                environmentVariables
+            );
             DetectArgumentService detectArgumentService = new DetectArgumentService(jenkinsIntLogger, mockedVersionHelper);
             DetectStrategyService detectStrategyService = new DetectStrategyService(jenkinsIntLogger, blankProxyHelper, WORKSPACE_TMP_REL_PATH, jenkinsConfigService);
 
@@ -197,7 +212,7 @@ public class DetectRunnerTest {
             //       run, which currently requires the setup above. Long term, the tests here should be redesigned so that we aren't
             //       performing all of the mocking. Until then, perform the assert below against all System.getenv() entries.
             System.getenv().forEach((key, value) ->
-                                        assertNotEquals(value, detectEnvCapture.getValue().getValue(value))
+                assertNotEquals(value, detectEnvCapture.getValue().getValue(value))
             );
 
             return cmdsArgCapture.getValue();

--- a/src/test/java/com/synopsys/integration/jenkins/detect/DetectRunnerTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/DetectRunnerTest.java
@@ -196,7 +196,7 @@ public class DetectRunnerTest {
             DetectArgumentService detectArgumentService = new DetectArgumentService(jenkinsIntLogger, mockedVersionHelper);
             DetectStrategyService detectStrategyService = new DetectStrategyService(jenkinsIntLogger, blankProxyHelper, WORKSPACE_TMP_REL_PATH, jenkinsConfigService);
 
-            DetectRunner detectRunner = new DetectRunner(detectEnvironmentService, mockedRemotingService, detectStrategyService, detectArgumentService);
+            DetectRunner detectRunner = new DetectRunner(detectEnvironmentService, mockedRemotingService, detectStrategyService, detectArgumentService, jenkinsIntLogger);
 
             // run the method we're testing
             detectRunner.runDetect(null, DETECT_PROPERTY_INPUT, detectDownloadStrategy);

--- a/src/test/java/com/synopsys/integration/jenkins/detect/service/DetectArgumentServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/service/DetectArgumentServiceTest.java
@@ -52,7 +52,7 @@ public class DetectArgumentServiceTest {
     public void setUp() {
         // Setup logger
         TaskListener taskListener = Mockito.mock(TaskListener.class);
-        JenkinsIntLogger jenkinsIntLogger = new JenkinsIntLogger(taskListener);
+        JenkinsIntLogger jenkinsIntLogger = JenkinsIntLogger.logToListener(taskListener);
 
         jenkinsIntLogger.setLogLevel(LogLevel.DEBUG);
         intEnvironmentVariables = IntEnvironmentVariables.includeSystemEnv();
@@ -87,13 +87,18 @@ public class DetectArgumentServiceTest {
 
     private String createDetectPropertiesInputString() {
         return inputDetectProperties.keySet().stream()
-                   .map(key -> key + "=" + inputDetectProperties.get(key))
-                   .collect(Collectors.joining(" "));
+            .map(key -> key + "=" + inputDetectProperties.get(key))
+            .collect(Collectors.joining(" "));
     }
 
     @Test
     public void testGetDetectArguments() {
-        List<String> detectCommandLine = detectArgumentService.getDetectArguments(intEnvironmentVariables, strategyEscaper, invocationParameters, createDetectPropertiesInputString());
+        List<String> detectCommandLine = detectArgumentService.getDetectArguments(
+            intEnvironmentVariables,
+            strategyEscaper,
+            invocationParameters,
+            createDetectPropertiesInputString()
+        );
 
         assertEquals(6, detectCommandLine.size()); // Invocation args (1) + passed args (2) + auto added args (3)
         commonValidation(detectCommandLine, expectedVisibleDetectProperties, expectedHiddenDetectProperties);
@@ -103,7 +108,12 @@ public class DetectArgumentServiceTest {
     public void testShouldEscapeFalse() {
         intEnvironmentVariables.put("DETECT_PLUGIN_ESCAPING", "false");
 
-        List<String> detectCommandLine = detectArgumentService.getDetectArguments(intEnvironmentVariables, strategyEscaper, invocationParameters, createDetectPropertiesInputString());
+        List<String> detectCommandLine = detectArgumentService.getDetectArguments(
+            intEnvironmentVariables,
+            strategyEscaper,
+            invocationParameters,
+            createDetectPropertiesInputString()
+        );
 
         assertEquals(6, detectCommandLine.size()); // Invocation args (1) + passed args (2) + auto added args (3)
         commonValidation(detectCommandLine, expectedVisibleDetectProperties, expectedHiddenDetectProperties);
@@ -117,7 +127,12 @@ public class DetectArgumentServiceTest {
         inputDetectProperties.put("--blackduck.trust.cert", "$TRUST_CERT");
         expectedVisibleDetectProperties.put("--blackduck.trust.cert", "false");
 
-        List<String> detectCommandLine = detectArgumentService.getDetectArguments(intEnvironmentVariables, strategyEscaper, invocationParameters, createDetectPropertiesInputString());
+        List<String> detectCommandLine = detectArgumentService.getDetectArguments(
+            intEnvironmentVariables,
+            strategyEscaper,
+            invocationParameters,
+            createDetectPropertiesInputString()
+        );
 
         assertEquals(7, detectCommandLine.size()); // Invocation args (1) + passed args (3) + auto added args (3)
         commonValidation(detectCommandLine, expectedVisibleDetectProperties, expectedHiddenDetectProperties);
@@ -127,12 +142,20 @@ public class DetectArgumentServiceTest {
     public void testVariableNotReplaced() {
         inputDetectProperties.put("$VISIBLE", "visible");
 
-        List<String> detectCommandLine = detectArgumentService.getDetectArguments(intEnvironmentVariables, strategyEscaper, invocationParameters, createDetectPropertiesInputString());
+        List<String> detectCommandLine = detectArgumentService.getDetectArguments(
+            intEnvironmentVariables,
+            strategyEscaper,
+            invocationParameters,
+            createDetectPropertiesInputString()
+        );
 
         assertEquals(7, detectCommandLine.size()); // Invocation args (1) + passed args (3) + auto added args (3)
         commonValidation(detectCommandLine, expectedVisibleDetectProperties, expectedHiddenDetectProperties);
 
-        assertTrue(byteArrayOutputStream.toString().contains("A variable may not have been properly replaced in resolved argument: $VISIBLE"), "Log should contain message about unable to replace variable.");
+        assertTrue(
+            byteArrayOutputStream.toString().contains("A variable may not have been properly replaced in resolved argument: $VISIBLE"),
+            "Log should contain message about unable to replace variable."
+        );
     }
 
     @Test
@@ -141,7 +164,12 @@ public class DetectArgumentServiceTest {
         inputDetectProperties.put(loggingLevelKey, expectedCustomLogLevel);
         expectedVisibleDetectProperties.replace(loggingLevelKey, expectedCustomLogLevel);
 
-        List<String> detectCommandLine = detectArgumentService.getDetectArguments(intEnvironmentVariables, strategyEscaper, invocationParameters, createDetectPropertiesInputString());
+        List<String> detectCommandLine = detectArgumentService.getDetectArguments(
+            intEnvironmentVariables,
+            strategyEscaper,
+            invocationParameters,
+            createDetectPropertiesInputString()
+        );
 
         assertEquals(6, detectCommandLine.size()); // Invocation args (1) + passed args (3) + auto added args (2)
         commonValidation(detectCommandLine, expectedVisibleDetectProperties, expectedHiddenDetectProperties);
@@ -162,7 +190,12 @@ public class DetectArgumentServiceTest {
         expectedHiddenDetectProperties.replace(jenkinsVersionParam, expectedJenkinsVersion, "<unknown>");
         expectedHiddenDetectProperties.replace(pluginVersionParam, expectedJenkinsPluginVersion, "<unknown>");
 
-        List<String> detectCommandLine = detectArgumentService.getDetectArguments(intEnvironmentVariables, strategyEscaper, invocationParameters, createDetectPropertiesInputString());
+        List<String> detectCommandLine = detectArgumentService.getDetectArguments(
+            intEnvironmentVariables,
+            strategyEscaper,
+            invocationParameters,
+            createDetectPropertiesInputString()
+        );
 
         assertEquals(6, detectCommandLine.size()); // Invocation args (1) + passed args (2) + auto added args (3)
         commonValidation(detectCommandLine, expectedVisibleDetectProperties, expectedHiddenDetectProperties);
@@ -172,7 +205,12 @@ public class DetectArgumentServiceTest {
     public void testEmptyIntEnvironmentVariables() {
         IntEnvironmentVariables intEnvironmentVariables = IntEnvironmentVariables.empty();
 
-        List<String> detectCommandLine = detectArgumentService.getDetectArguments(intEnvironmentVariables, strategyEscaper, invocationParameters, createDetectPropertiesInputString());
+        List<String> detectCommandLine = detectArgumentService.getDetectArguments(
+            intEnvironmentVariables,
+            strategyEscaper,
+            invocationParameters,
+            createDetectPropertiesInputString()
+        );
 
         assertEquals(6, detectCommandLine.size()); // Invocation args (1) + passed args (2) + auto added args (3)
         commonValidation(detectCommandLine, expectedVisibleDetectProperties, expectedHiddenDetectProperties);

--- a/src/test/java/com/synopsys/integration/jenkins/detect/service/DetectEnvironmentServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/service/DetectEnvironmentServiceTest.java
@@ -30,7 +30,7 @@ import hudson.model.TaskListener;
 public class DetectEnvironmentServiceTest {
     private final TaskListener taskListenerMock = Mockito.mock(TaskListener.class);
     private final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    private final JenkinsIntLogger jenkinsIntLogger = new JenkinsIntLogger(taskListenerMock);
+    private final JenkinsIntLogger jenkinsIntLogger = JenkinsIntLogger.logToListener(taskListenerMock);
 
     public final BlackDuckServerConfigBuilder blackDuckServerConfigBuilder = BlackDuckServerConfig.newBuilder().setTimeoutInSeconds(120);
 
@@ -53,7 +53,14 @@ public class DetectEnvironmentServiceTest {
         Mockito.when(jenkinsConfigServiceMock.getGlobalConfiguration(DetectGlobalConfig.class)).thenReturn(Optional.of(detectGlobalConfig));
         Mockito.when(detectGlobalConfig.getBlackDuckServerConfigBuilder(jenkinsProxyHelper, synopsysCredentialsHelper)).thenReturn(blackDuckServerConfigBuilder);
 
-        detectEnvironmentService = new DetectEnvironmentService(jenkinsIntLogger, jenkinsProxyHelper, jenkinsVersionHelperMock, synopsysCredentialsHelper, jenkinsConfigServiceMock, new HashMap<>());
+        detectEnvironmentService = new DetectEnvironmentService(
+            jenkinsIntLogger,
+            jenkinsProxyHelper,
+            jenkinsVersionHelperMock,
+            synopsysCredentialsHelper,
+            jenkinsConfigServiceMock,
+            new HashMap<>()
+        );
     }
 
     @Test
@@ -68,8 +75,10 @@ public class DetectEnvironmentServiceTest {
         Mockito.when(jenkinsVersionHelperMock.getPluginVersion("blackduck-detect")).thenReturn(Optional.of(expectedJenkinsPluginVersion));
 
         detectEnvironmentService.createDetectEnvironment();
-        assertTrue(byteArrayOutputStream.toString().contains(String.format("Running Synopsys Detect for Jenkins version: %s", expectedJenkinsPluginVersion)),
-            "Log should contain message with plugin version");
+        assertTrue(
+            byteArrayOutputStream.toString().contains(String.format("Running Synopsys Detect for Jenkins version: %s", expectedJenkinsPluginVersion)),
+            "Log should contain message with plugin version"
+        );
     }
 
     @Test
@@ -79,7 +88,10 @@ public class DetectEnvironmentServiceTest {
         blackDuckServerConfigBuilder.setTimeoutInSeconds(null);
         assertTrue(blackDuckServerConfigBuilder.getEnvironmentVariableKeys().contains(junitKey), String.format("Should contain key %s", junitKey));
         assertTrue(blackDuckServerConfigBuilder.getProperties().containsValue(junitValue), String.format("Should contain value %s", junitValue));
-        assertTrue(blackDuckServerConfigBuilder.getProperties().containsKey(BlackDuckServerConfigBuilder.TIMEOUT_KEY), String.format("Should contain %s", BlackDuckServerConfigBuilder.TIMEOUT_KEY));
+        assertTrue(
+            blackDuckServerConfigBuilder.getProperties().containsKey(BlackDuckServerConfigBuilder.TIMEOUT_KEY),
+            String.format("Should contain %s", BlackDuckServerConfigBuilder.TIMEOUT_KEY)
+        );
 
         IntEnvironmentVariables intEnvironmentVariables = detectEnvironmentService.createDetectEnvironment();
         assertFalse(intEnvironmentVariables.containsKey(junitKey), String.format("Should NOT contain key %s", junitKey));
@@ -99,7 +111,14 @@ public class DetectEnvironmentServiceTest {
     public void testEnvironmentAdded() {
         Map<String, String> environmentVariables = new HashMap<>();
         environmentVariables.put(junitKey, junitValue);
-        detectEnvironmentService = new DetectEnvironmentService(jenkinsIntLogger, jenkinsProxyHelper, jenkinsVersionHelperMock, synopsysCredentialsHelper, jenkinsConfigServiceMock, environmentVariables);
+        detectEnvironmentService = new DetectEnvironmentService(
+            jenkinsIntLogger,
+            jenkinsProxyHelper,
+            jenkinsVersionHelperMock,
+            synopsysCredentialsHelper,
+            jenkinsConfigServiceMock,
+            environmentVariables
+        );
         IntEnvironmentVariables intEnvironmentVariables = detectEnvironmentService.createDetectEnvironment();
 
         assertTrue(intEnvironmentVariables.containsKey(junitKey), String.format("Should contain key %s", junitKey));
@@ -108,10 +127,16 @@ public class DetectEnvironmentServiceTest {
 
     @Test
     public void testRenameEnvironmentVariable() {
-        assertTrue(blackDuckServerConfigBuilder.getProperties().containsKey(BlackDuckServerConfigBuilder.TIMEOUT_KEY), String.format("Should contain %s", BlackDuckServerConfigBuilder.TIMEOUT_KEY));
+        assertTrue(
+            blackDuckServerConfigBuilder.getProperties().containsKey(BlackDuckServerConfigBuilder.TIMEOUT_KEY),
+            String.format("Should contain %s", BlackDuckServerConfigBuilder.TIMEOUT_KEY)
+        );
 
         IntEnvironmentVariables intEnvironmentVariables = detectEnvironmentService.createDetectEnvironment();
-        assertFalse(intEnvironmentVariables.containsKey(BlackDuckServerConfigBuilder.TIMEOUT_KEY.getKey()), String.format("Should NOT contain %s", BlackDuckServerConfigBuilder.TIMEOUT_KEY));
+        assertFalse(
+            intEnvironmentVariables.containsKey(BlackDuckServerConfigBuilder.TIMEOUT_KEY.getKey()),
+            String.format("Should NOT contain %s", BlackDuckServerConfigBuilder.TIMEOUT_KEY)
+        );
         assertTrue(intEnvironmentVariables.containsKey(DetectEnvironmentService.TIMEOUT), String.format("Should contain key %s", DetectEnvironmentService.TIMEOUT));
     }
 

--- a/src/test/java/com/synopsys/integration/jenkins/detect/service/DetectEnvironmentServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/service/DetectEnvironmentServiceTest.java
@@ -68,7 +68,7 @@ public class DetectEnvironmentServiceTest {
     @Test
     public void testNoPluginVersionInLog() {
         detectEnvironmentService.createDetectEnvironment();
-        assertTrue(byteArrayOutputStream.toString().contains("Running Synopsys Detect for Jenkins"), "Log should contain default message");
+        assertTrue(byteArrayOutputStream.toString().contains("Running Synopsys Detect Plugin for Jenkins"), "Log should contain default message");
     }
 
     @Test
@@ -78,7 +78,7 @@ public class DetectEnvironmentServiceTest {
 
         detectEnvironmentService.createDetectEnvironment();
         assertTrue(
-            byteArrayOutputStream.toString().contains(String.format("Running Synopsys Detect for Jenkins version: %s", expectedJenkinsPluginVersion)),
+            byteArrayOutputStream.toString().contains(String.format("Running Synopsys Detect Plugin for Jenkins version: %s", expectedJenkinsPluginVersion)),
             "Log should contain message with plugin version"
         );
     }

--- a/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectAirGapJarStrategyTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectAirGapJarStrategyTest.java
@@ -59,10 +59,12 @@ public class DetectAirGapJarStrategyTest {
     private File tempAirGapJar;
 
     public static Stream<Arguments> testJavaHomeSource() {
-        return Stream.of(Arguments.of(" ", System.getProperty("user.dir") + File.separator + " " + REMOTE_JAVA_RELATIVE_PATH),
+        return Stream.of(
+            Arguments.of(" ", System.getProperty("user.dir") + File.separator + " " + REMOTE_JAVA_RELATIVE_PATH),
             Arguments.of("", new File(REMOTE_JAVA_RELATIVE_PATH).getAbsolutePath()),
             Arguments.of(null, "java"),
-            Arguments.of(REMOTE_JDK_HOME, EXPECTED_JAVA_FULL_PATH));
+            Arguments.of(REMOTE_JDK_HOME, EXPECTED_JAVA_FULL_PATH)
+        );
     }
 
     @BeforeEach
@@ -74,17 +76,24 @@ public class DetectAirGapJarStrategyTest {
         byteArrayOutputStream = new ByteArrayOutputStream();
         Mockito.when(taskListener.getLogger()).thenReturn(new PrintStream(byteArrayOutputStream));
 
-        logger = new JenkinsIntLogger(taskListener);
+        logger = JenkinsIntLogger.logToListener(taskListener);
 
         tempJarDirectoryPathName = createTempAirGapDirectory().getPath();
         tempAirGapJar = createTempAirGapJar(DetectAirGapJarStrategy.DETECT_JAR_PREFIX, DetectAirGapJarStrategy.DETECT_JAR_SUFFIX);
 
-        Mockito.doReturn(Optional.of(detectAirGapInstallationMock)).when(jenkinsConfigServiceMock).getInstallationForNodeAndEnvironment(DetectAirGapInstallation.DescriptorImpl.class, AIRGAP_TOOL_NAME);
+        Mockito.doReturn(Optional.of(detectAirGapInstallationMock)).when(jenkinsConfigServiceMock)
+            .getInstallationForNodeAndEnvironment(DetectAirGapInstallation.DescriptorImpl.class, AIRGAP_TOOL_NAME);
     }
 
     @Test
     public void testArgumentEscaper() {
-        DetectAirGapJarStrategy detectAirGapJarStrategy = new DetectAirGapJarStrategy(logger, environmentVariables, REMOTE_JDK_HOME, jenkinsConfigServiceMock, AIRGAP_DOWNLOAD_STRATEGY);
+        DetectAirGapJarStrategy detectAirGapJarStrategy = new DetectAirGapJarStrategy(
+            logger,
+            environmentVariables,
+            REMOTE_JDK_HOME,
+            jenkinsConfigServiceMock,
+            AIRGAP_DOWNLOAD_STRATEGY
+        );
         assertEquals(Function.identity(), detectAirGapJarStrategy.getArgumentEscaper());
     }
 
@@ -157,8 +166,10 @@ public class DetectAirGapJarStrategyTest {
         }
 
         DetectJenkinsException exception = assertThrows(DetectJenkinsException.class, () -> configureCallable(REMOTE_JDK_HOME, tempJarDirectoryPathName).getSetupCallable().call());
-        assertTrue(exception.getMessage().contains(String.format("Problem encountered getting Detect Air Gap tool with the name %s from global tool configuration.", AIRGAP_TOOL_NAME)),
-            "Stacktrace does not contain expected message: " + exception.getMessage());
+        assertTrue(
+            exception.getMessage().contains(String.format("Problem encountered getting Detect Air Gap tool with the name %s from global tool configuration.", AIRGAP_TOOL_NAME)),
+            "Stacktrace does not contain expected message: " + exception.getMessage()
+        );
     }
 
     @Test
@@ -171,13 +182,17 @@ public class DetectAirGapJarStrategyTest {
 
         DetectJenkinsException exception = assertThrows(DetectJenkinsException.class, () -> configureCallable(REMOTE_JDK_HOME, tempJarDirectoryPathName).getSetupCallable().call());
         assertTrue(exception.getCause() instanceof IOException, "Expected an IOException to be thrown");
-        assertTrue(exception.getMessage().contains("Problem encountered while interacting with Jenkins environment."), "Stacktrace does not contain expected message: " + exception.getMessage());
+        assertTrue(
+            exception.getMessage().contains("Problem encountered while interacting with Jenkins environment."),
+            "Stacktrace does not contain expected message: " + exception.getMessage()
+        );
     }
 
     @Test
     public void testInterruptedExceptionGetToolName() {
         try {
-            Mockito.doThrow(InterruptedException.class).when(jenkinsConfigServiceMock).getInstallationForNodeAndEnvironment(DetectAirGapInstallation.DescriptorImpl.class, AIRGAP_TOOL_NAME);
+            Mockito.doThrow(InterruptedException.class).when(jenkinsConfigServiceMock)
+                .getInstallationForNodeAndEnvironment(DetectAirGapInstallation.DescriptorImpl.class, AIRGAP_TOOL_NAME);
         } catch (Exception e) {
             fail("Unexpected exception mocking call to getInstallationForNodeAndEnvironment");
         }
@@ -231,8 +246,10 @@ public class DetectAirGapJarStrategyTest {
         createTempAirGapJar(DetectAirGapJarStrategy.DETECT_JAR_PREFIX, DetectAirGapJarStrategy.DETECT_JAR_SUFFIX);
 
         DetectJenkinsException exception = assertThrows(DetectJenkinsException.class, () -> configureCallable(REMOTE_JDK_HOME, tempJarDirectoryPathName).getSetupCallable().call());
-        assertTrue(exception.getMessage().contains(String.format(EXPECTED_ONE_JAR_ERROR_MSG + " and instead found %d jars", tempJarDirectoryPathName, 2)),
-            "Stacktrace does not contain expected message.");
+        assertTrue(
+            exception.getMessage().contains(String.format(EXPECTED_ONE_JAR_ERROR_MSG + " and instead found %d jars", tempJarDirectoryPathName, 2)),
+            "Stacktrace does not contain expected message."
+        );
     }
 
     private void executeAndValidateSetupCallable(String javaHomeInput, String expectedJavaPath, String toolHomeDirectory, File expectedAirGapJar) {

--- a/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectJarStrategyTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectJarStrategyTest.java
@@ -45,10 +45,12 @@ public class DetectJarStrategyTest {
     private ByteArrayOutputStream byteArrayOutputStream;
 
     public static Stream<Arguments> testSetupCallableJavaHomeSource() {
-        return Stream.of(Arguments.of(" ", System.getProperty("user.dir") + File.separator + " " + REMOTE_JAVA_RELATIVE_PATH),
+        return Stream.of(
+            Arguments.of(" ", System.getProperty("user.dir") + File.separator + " " + REMOTE_JAVA_RELATIVE_PATH),
             Arguments.of("", new File(REMOTE_JAVA_RELATIVE_PATH).getAbsolutePath()),
             Arguments.of(null, "java"),
-            Arguments.of(REMOTE_JDK_HOME, EXPECTED_JAVA_FULL_PATH));
+            Arguments.of(REMOTE_JDK_HOME, EXPECTED_JAVA_FULL_PATH)
+        );
     }
 
     @BeforeEach
@@ -60,7 +62,7 @@ public class DetectJarStrategyTest {
         byteArrayOutputStream = new ByteArrayOutputStream();
         Mockito.when(taskListener.getLogger()).thenReturn(new PrintStream(byteArrayOutputStream));
 
-        logger = new JenkinsIntLogger(taskListener);
+        logger = JenkinsIntLogger.logToListener(taskListener);
     }
 
     @Test

--- a/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectScriptStrategyCallableTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectScriptStrategyCallableTest.java
@@ -40,7 +40,7 @@ public class DetectScriptStrategyCallableTest {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         TaskListener mockedTaskListener = Mockito.mock(TaskListener.class);
         Mockito.when(mockedTaskListener.getLogger()).thenReturn(new PrintStream(byteArrayOutputStream));
-        defaultLogger = new JenkinsIntLogger(mockedTaskListener);
+        defaultLogger = JenkinsIntLogger.logToListener(mockedTaskListener);
         defaultProxyHelper = new JenkinsProxyHelper();
 
         try {

--- a/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectScriptStrategyCallableTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectScriptStrategyCallableTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import com.google.gson.Gson;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.jenkins.extensions.JenkinsIntLogger;
 import com.synopsys.integration.jenkins.wrapper.JenkinsProxyHelper;
@@ -76,7 +77,13 @@ public class DetectScriptStrategyCallableTest {
         assumeTrue(new File(toolsDirectoryPath).setReadOnly(), "Skipping test because we can't modify file permissions.");
         assumeFalse(new File(toolsDirectoryPath).canWrite(), "Skipping as test can still write. Possibly running as root.");
 
-        DetectScriptStrategy detectScriptStrategy = new DetectScriptStrategy(defaultLogger, defaultProxyHelper, OperatingSystemType.determineFromSystem(), toolsDirectoryPath);
+        DetectScriptStrategy detectScriptStrategy = new DetectScriptStrategy(
+            defaultLogger,
+            defaultProxyHelper,
+            OperatingSystemType.determineFromSystem(),
+            toolsDirectoryPath,
+            new Gson()
+        );
 
         try {
             assertThrows(IntegrationException.class, detectScriptStrategy.getSetupCallable()::call);
@@ -103,7 +110,7 @@ public class DetectScriptStrategyCallableTest {
         try {
             String expectedScriptPath = new File(toolsDirectoryPath, DetectScriptStrategy.DETECT_INSTALL_DIRECTORY).getPath();
 
-            DetectScriptStrategy detectScriptStrategy = new DetectScriptStrategy(defaultLogger, defaultProxyHelper, operatingSystemType, toolsDirectoryPath);
+            DetectScriptStrategy detectScriptStrategy = new DetectScriptStrategy(defaultLogger, defaultProxyHelper, operatingSystemType, toolsDirectoryPath, new Gson());
             ArrayList<String> scriptStrategyArgs = detectScriptStrategy.getSetupCallable().call();
             File remoteScriptFile = new File(parseScriptStrategyArgs(scriptStrategyArgs));
 

--- a/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectScriptStrategyTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectScriptStrategyTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import com.google.gson.Gson;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.jenkins.extensions.JenkinsIntLogger;
 import com.synopsys.integration.jenkins.wrapper.JenkinsProxyHelper;
@@ -39,7 +40,7 @@ public class DetectScriptStrategyTest {
 
         JenkinsProxyHelper mockedProxyHelper = Mockito.mock(JenkinsProxyHelper.class);
         Mockito.when(mockedProxyHelper.getProxyInfo(Mockito.anyString())).thenThrow(new IllegalArgumentException(expectedExceptionMessage));
-        DetectScriptStrategy detectScriptStrategy = new DetectScriptStrategy(defaultLogger, mockedProxyHelper, OperatingSystemType.LINUX, null);
+        DetectScriptStrategy detectScriptStrategy = new DetectScriptStrategy(defaultLogger, mockedProxyHelper, OperatingSystemType.LINUX, null, new Gson());
 
         try {
             detectScriptStrategy.getSetupCallable();
@@ -52,7 +53,7 @@ public class DetectScriptStrategyTest {
 
     @Test
     public void testArgumentEscaperLinux() {
-        DetectScriptStrategy detectScriptStrategy = new DetectScriptStrategy(defaultLogger, defaultProxyHelper, OperatingSystemType.LINUX, null);
+        DetectScriptStrategy detectScriptStrategy = new DetectScriptStrategy(defaultLogger, defaultProxyHelper, OperatingSystemType.LINUX, null, new Gson());
         String expectedEscapedString = "\\|\\&\\;\\<\\>\\(\\)\\$\\`\\\\\\\"\\'\\ \\\t\\*\\?\\[\\#\\~\\=\\%,";
 
         String escapedString = detectScriptStrategy.getArgumentEscaper().apply(unescapedSpecialCharacters);
@@ -62,7 +63,7 @@ public class DetectScriptStrategyTest {
 
     @Test
     public void testArgumentEscaperMac() {
-        DetectScriptStrategy detectScriptStrategy = new DetectScriptStrategy(defaultLogger, defaultProxyHelper, OperatingSystemType.MAC, null);
+        DetectScriptStrategy detectScriptStrategy = new DetectScriptStrategy(defaultLogger, defaultProxyHelper, OperatingSystemType.MAC, null, new Gson());
         String expectedEscapedString = "\\|\\&\\;\\<\\>\\(\\)\\$\\`\\\\\\\"\\'\\ \\\t\\*\\?\\[\\#\\~\\=\\%,";
 
         String escapedString = detectScriptStrategy.getArgumentEscaper().apply(unescapedSpecialCharacters);
@@ -72,7 +73,7 @@ public class DetectScriptStrategyTest {
 
     @Test
     public void testArgumentEscaperWindows() {
-        DetectScriptStrategy detectScriptStrategy = new DetectScriptStrategy(defaultLogger, defaultProxyHelper, OperatingSystemType.WINDOWS, null);
+        DetectScriptStrategy detectScriptStrategy = new DetectScriptStrategy(defaultLogger, defaultProxyHelper, OperatingSystemType.WINDOWS, null, new Gson());
         String expectedEscapedString = "`|`&`;`<`>`(`)`$```\\`\"`'` `\t`*`?`[`#`~`=`%`,";
 
         String escapedString = detectScriptStrategy.getArgumentEscaper().apply(unescapedSpecialCharacters);

--- a/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectScriptStrategyTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectScriptStrategyTest.java
@@ -29,7 +29,7 @@ public class DetectScriptStrategyTest {
         logs = new ByteArrayOutputStream();
         TaskListener mockedTaskListener = Mockito.mock(TaskListener.class);
         Mockito.when(mockedTaskListener.getLogger()).thenReturn(new PrintStream(logs));
-        defaultLogger = new JenkinsIntLogger(mockedTaskListener);
+        defaultLogger = JenkinsIntLogger.logToListener(mockedTaskListener);
         defaultProxyHelper = new JenkinsProxyHelper();
     }
 

--- a/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectStrategyServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectStrategyServiceTest.java
@@ -44,7 +44,7 @@ public class DetectStrategyServiceTest {
         TaskListener taskListener = Mockito.mock(TaskListener.class);
         byteArrayOutputStream = new ByteArrayOutputStream();
         Mockito.when(taskListener.getLogger()).thenReturn(new PrintStream(byteArrayOutputStream));
-        JenkinsIntLogger logger = new JenkinsIntLogger(taskListener);
+        JenkinsIntLogger logger = JenkinsIntLogger.logToListener(taskListener);
 
         jenkinsConfigService = Mockito.mock(JenkinsConfigService.class);
         detectStrategyService = new DetectStrategyService(logger, null, null, jenkinsConfigService);


### PR DESCRIPTION
This PR addresses multiple tickets:

IDTCTJNKNS-224 - Request to include log messages to specifically call out the start/end of running Detect.
ex:

IDTCTJNKNS-239 - The logging of the Detect command from the plugin has been removed. The Detect script AND the jar already do this.

IDTCTJNKNS-247/IDTCTJNKNS-253 - Improve logging messages so it is clearer what is happening.

IDTCTJNKNS-254 - Only escape the Detect parameter value and not the key.
Previous: `--detect.project.name\=Test\ Project`
New: `--detect.project.name=Test\ Project`

Update any impacted tests.