### PR TITLE
Updates to improve/fix logging messages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 project.ext.excludesFromTestCoverage = ['**/DetectDownloadStrategy.java', '**/DetectPipelineStep.java', '**/DetectPostBuildStep.java', '**/DetectAirGapInstallation.java']
 
 group = 'com.blackducksoftware.integration'
-version = '7.1.0-SNAPSHOT'
+version = '8.0.0-SNAPSHOT'
 description = 'Synopsys Detect Plugin for Jenkins'
 
 repositories {

--- a/src/main/java/com/synopsys/integration/jenkins/detect/DetectRunner.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/DetectRunner.java
@@ -16,32 +16,64 @@ import com.synopsys.integration.jenkins.detect.service.DetectArgumentService;
 import com.synopsys.integration.jenkins.detect.service.DetectEnvironmentService;
 import com.synopsys.integration.jenkins.detect.service.strategy.DetectExecutionStrategy;
 import com.synopsys.integration.jenkins.detect.service.strategy.DetectStrategyService;
+import com.synopsys.integration.jenkins.extensions.JenkinsIntLogger;
 import com.synopsys.integration.jenkins.service.JenkinsRemotingService;
 import com.synopsys.integration.util.IntEnvironmentVariables;
 import com.synopsys.integration.util.OperatingSystemType;
 
 public class DetectRunner {
+    public static final String ASTERISKS = "******************************************************************************";
+
     private final DetectEnvironmentService detectEnvironmentService;
     private final JenkinsRemotingService remotingService;
     private final DetectStrategyService detectStrategyService;
     private final DetectArgumentService detectArgumentService;
+    private final JenkinsIntLogger logger;
 
-    public DetectRunner(DetectEnvironmentService detectEnvironmentService, JenkinsRemotingService remotingService, DetectStrategyService detectStrategyService, DetectArgumentService detectArgumentService) {
+    public DetectRunner(
+        DetectEnvironmentService detectEnvironmentService,
+        JenkinsRemotingService remotingService,
+        DetectStrategyService detectStrategyService,
+        DetectArgumentService detectArgumentService,
+        JenkinsIntLogger logger
+    ) {
         this.detectEnvironmentService = detectEnvironmentService;
         this.remotingService = remotingService;
         this.detectStrategyService = detectStrategyService;
         this.detectArgumentService = detectArgumentService;
+        this.logger = logger;
     }
 
-    public int runDetect(String remoteJdkHome, String detectArgumentString, DetectDownloadStrategy detectDownloadStrategy) throws IOException, InterruptedException, IntegrationException {
+    public int runDetect(String remoteJdkHome, String detectArgumentString, DetectDownloadStrategy detectDownloadStrategy)
+        throws IOException, InterruptedException, IntegrationException {
         IntEnvironmentVariables intEnvironmentVariables = detectEnvironmentService.createDetectEnvironment();
         OperatingSystemType operatingSystemType = remotingService.getRemoteOperatingSystemType();
-        DetectExecutionStrategy detectExecutionStrategy = detectStrategyService.getExecutionStrategy(intEnvironmentVariables, operatingSystemType, remoteJdkHome, detectDownloadStrategy);
+        DetectExecutionStrategy detectExecutionStrategy = detectStrategyService.getExecutionStrategy(
+            intEnvironmentVariables,
+            operatingSystemType,
+            remoteJdkHome,
+            detectDownloadStrategy
+        );
 
         List<String> initialArguments = remotingService.call(detectExecutionStrategy.getSetupCallable());
 
-        List<String> detectCommands = detectArgumentService.getDetectArguments(intEnvironmentVariables, detectExecutionStrategy.getArgumentEscaper(), initialArguments, detectArgumentString);
+        List<String> detectCommands = detectArgumentService.getDetectArguments(
+            intEnvironmentVariables,
+            detectExecutionStrategy.getArgumentEscaper(),
+            initialArguments,
+            detectArgumentString
+        );
 
-        return remotingService.launch(intEnvironmentVariables, detectCommands);
+        logger.info(ASTERISKS);
+        logger.info("START OF DETECT");
+        logger.info(ASTERISKS);
+
+        int detectRun = remotingService.launch(intEnvironmentVariables, detectCommands);
+
+        logger.info(ASTERISKS);
+        logger.info("END OF DETECT");
+        logger.info(ASTERISKS);
+
+        return detectRun;
     }
 }

--- a/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectArgumentService.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectArgumentService.java
@@ -98,16 +98,13 @@ public class DetectArgumentService {
     }
 
     private String escapeArgument(String argument, Function<String, String> escaper) {
-        String detectPropertyName = "";
-        String detectPropertyValue = "";
+        // Assume a cleaned argument, then test
+        String cleanedArg = argument;
         if (argument.startsWith("--") && argument.contains("=")) {
             String[] splitArgument = argument.split("=", 2);
-            detectPropertyName = splitArgument[0];
-            detectPropertyValue = splitArgument[1];
-        } else {
-            detectPropertyValue = argument;
+            cleanedArg = splitArgument[0] + "=" + escaper.apply(splitArgument[1]);
         }
 
-        return detectPropertyName + "=" + escaper.apply(detectPropertyValue);
+        return cleanedArg;
     }
 }

--- a/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectCommandsFactory.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectCommandsFactory.java
@@ -91,12 +91,13 @@ public class DetectCommandsFactory {
         return new DetectPipelineCommands(detectCommandsFactory.createDetectRunner(jenkinsConfigService, jenkinsRemotingService), detectCommandsFactory.getLogger());
     }
 
-    private DetectRunner createDetectRunner(JenkinsConfigService jenkinsConfigService, JenkinsRemotingService jenkinsRemotingService) throws AbortException {
+    private DetectRunner createDetectRunner(JenkinsConfigService jenkinsConfigService, JenkinsRemotingService jenkinsRemotingService) {
         return new DetectRunner(
             createDetectEnvironmentService(jenkinsConfigService),
             jenkinsRemotingService,
             createDetectStrategyService(jenkinsConfigService),
-            createDetectArgumentService()
+            createDetectArgumentService(),
+            getLogger()
         );
     }
 

--- a/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectEnvironmentService.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectEnvironmentService.java
@@ -32,8 +32,14 @@ public class DetectEnvironmentService {
     private final Map<String, String> environmentVariables;
     private final JenkinsConfigService jenkinsConfigService;
 
-    public DetectEnvironmentService(JenkinsIntLogger logger, JenkinsProxyHelper jenkinsProxyHelper, JenkinsVersionHelper jenkinsVersionHelper, SynopsysCredentialsHelper synopsysCredentialsHelper, JenkinsConfigService jenkinsConfigService,
-        Map<String, String> environmentVariables) {
+    public DetectEnvironmentService(
+        JenkinsIntLogger logger,
+        JenkinsProxyHelper jenkinsProxyHelper,
+        JenkinsVersionHelper jenkinsVersionHelper,
+        SynopsysCredentialsHelper synopsysCredentialsHelper,
+        JenkinsConfigService jenkinsConfigService,
+        Map<String, String> environmentVariables
+    ) {
         this.logger = logger;
         this.jenkinsProxyHelper = jenkinsProxyHelper;
         this.jenkinsVersionHelper = jenkinsVersionHelper;
@@ -51,9 +57,9 @@ public class DetectEnvironmentService {
 
         Optional<String> pluginVersion = jenkinsVersionHelper.getPluginVersion("blackduck-detect");
         if (pluginVersion.isPresent()) {
-            logger.info("Running Synopsys Detect for Jenkins version: " + pluginVersion.get());
+            logger.info("Running Synopsys Detect Plugin for Jenkins version: " + pluginVersion.get());
         } else {
-            logger.info("Running Synopsys Detect for Jenkins");
+            logger.info("Running Synopsys Detect Plugin for Jenkins");
         }
 
         return intEnvironmentVariables;

--- a/src/main/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectScriptStrategy.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectScriptStrategy.java
@@ -148,7 +148,7 @@ public class DetectScriptStrategy extends DetectExecutionStrategy {
 
                 logger.info(String.format("Downloading Detect script from %s to %s", scriptUrl, detectScriptPath));
 
-                IntHttpClient intHttpClient = new IntHttpClient(logger, gson, 120, true, rebuildProxyInfo());
+                IntHttpClient intHttpClient = new IntHttpClient(logger, gson, 120, false, rebuildProxyInfo());
                 Request request = new Request.Builder().url(new HttpUrl(scriptUrl)).build();
 
                 try (Response response = intHttpClient.execute(request)) {

--- a/src/test/java/com/synopsys/integration/jenkins/detect/DetectRunnerTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/DetectRunnerTest.java
@@ -82,12 +82,12 @@ public class DetectRunnerTest {
         int i = 0;
         assertEquals("bash", actualCommand.get(i++));
         assertEquals(DETECT_SHELL_PATH, actualCommand.get(i++));
-        assertEquals("--detect.docker.passthrough.service.timeout\\=120", actualCommand.get(i++));
-        assertEquals("--detect.cleanup\\=false", actualCommand.get(i++));
-        assertEquals("--detect.project.name\\=Test\\ Project\\'", actualCommand.get(i++));
-        assertEquals("--logging.level.com.synopsys.integration\\=INFO", actualCommand.get(i++));
-        assertTrue(actualCommand.get(i++).startsWith("--detect.phone.home.passthrough.jenkins.version\\="));
-        assertTrue(actualCommand.get(i).startsWith("--detect.phone.home.passthrough.jenkins.plugin.version\\="));
+        assertEquals("--detect.docker.passthrough.service.timeout=120", actualCommand.get(i++));
+        assertEquals("--detect.cleanup=false", actualCommand.get(i++));
+        assertEquals("--detect.project.name=Test\\ Project\\'", actualCommand.get(i++));
+        assertEquals("--logging.level.com.synopsys.integration=INFO", actualCommand.get(i++));
+        assertTrue(actualCommand.get(i++).startsWith("--detect.phone.home.passthrough.jenkins.version="));
+        assertTrue(actualCommand.get(i).startsWith("--detect.phone.home.passthrough.jenkins.plugin.version="));
     }
 
     @Test
@@ -100,12 +100,12 @@ public class DetectRunnerTest {
         int i = 0;
         assertEquals("powershell", actualCommand.get(i++));
         assertEquals("\"Import-Module '" + DETECT_POWERSHELL_PATH + "'; detect\"", actualCommand.get(i++));
-        assertEquals("--detect.docker.passthrough.service.timeout`=120", actualCommand.get(i++));
-        assertEquals("--detect.cleanup`=false", actualCommand.get(i++));
-        assertEquals("--detect.project.name`=Test` Project`'", actualCommand.get(i++));
-        assertEquals("--logging.level.com.synopsys.integration`=INFO", actualCommand.get(i++));
-        assertTrue(actualCommand.get(i++).startsWith("--detect.phone.home.passthrough.jenkins.version`="));
-        assertTrue(actualCommand.get(i).startsWith("--detect.phone.home.passthrough.jenkins.plugin.version`="));
+        assertEquals("--detect.docker.passthrough.service.timeout=120", actualCommand.get(i++));
+        assertEquals("--detect.cleanup=false", actualCommand.get(i++));
+        assertEquals("--detect.project.name=Test` Project`'", actualCommand.get(i++));
+        assertEquals("--logging.level.com.synopsys.integration=INFO", actualCommand.get(i++));
+        assertTrue(actualCommand.get(i++).startsWith("--detect.phone.home.passthrough.jenkins.version="));
+        assertTrue(actualCommand.get(i).startsWith("--detect.phone.home.passthrough.jenkins.plugin.version="));
     }
 
     @Test

--- a/src/test/java/com/synopsys/integration/jenkins/detect/DetectRunnerTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/DetectRunnerTest.java
@@ -196,7 +196,7 @@ public class DetectRunnerTest {
             DetectArgumentService detectArgumentService = new DetectArgumentService(jenkinsIntLogger, mockedVersionHelper);
             DetectStrategyService detectStrategyService = new DetectStrategyService(jenkinsIntLogger, blankProxyHelper, WORKSPACE_TMP_REL_PATH, jenkinsConfigService);
 
-            DetectRunner detectRunner = new DetectRunner(detectEnvironmentService, mockedRemotingService, detectStrategyService, detectArgumentService);
+            DetectRunner detectRunner = new DetectRunner(detectEnvironmentService, mockedRemotingService, detectStrategyService, detectArgumentService, jenkinsIntLogger);
 
             // run the method we're testing
             detectRunner.runDetect(null, DETECT_PROPERTY_INPUT, detectDownloadStrategy);

--- a/src/test/java/com/synopsys/integration/jenkins/detect/service/DetectEnvironmentServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/service/DetectEnvironmentServiceTest.java
@@ -68,7 +68,7 @@ public class DetectEnvironmentServiceTest {
     @Test
     public void testNoPluginVersionInLog() {
         detectEnvironmentService.createDetectEnvironment();
-        assertTrue(byteArrayOutputStream.toString().contains("Running Synopsys Detect for Jenkins"), "Log should contain default message");
+        assertTrue(byteArrayOutputStream.toString().contains("Running Synopsys Detect Plugin for Jenkins"), "Log should contain default message");
     }
 
     @Test
@@ -78,7 +78,7 @@ public class DetectEnvironmentServiceTest {
 
         detectEnvironmentService.createDetectEnvironment();
         assertTrue(
-            byteArrayOutputStream.toString().contains(String.format("Running Synopsys Detect for Jenkins version: %s", expectedJenkinsPluginVersion)),
+            byteArrayOutputStream.toString().contains(String.format("Running Synopsys Detect Plugin for Jenkins version: %s", expectedJenkinsPluginVersion)),
             "Log should contain message with plugin version"
         );
     }


### PR DESCRIPTION
This PR addresses multiple tickets:

IDTCTJNKNS-224 - Request to include log messages to specifically call out the start/end of running Detect.
ex:

IDTCTJNKNS-239 - The logging of the Detect command from the plugin has been removed. The Detect script AND the jar already do this.

IDTCTJNKNS-247/IDTCTJNKNS-253 - Improve logging messages so it is clearer what is happening.

IDTCTJNKNS-254 - Only escape the Detect parameter value and not the key.
Previous: --detect.project.name\=Test\ Project
New: --detect.project.name=Test\ Project

Update any impacted tests.