### PR TITLE
IDTCTJNKNS-220: Do not set unstable on IntegrationException

### DIFF
--- a/src/main/java/com/synopsys/integration/jenkins/detect/DetectFreestyleCommands.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/DetectFreestyleCommands.java
@@ -7,7 +7,6 @@
  */
 package com.synopsys.integration.jenkins.detect;
 
-import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.jenkins.detect.extensions.DetectDownloadStrategy;
 import com.synopsys.integration.jenkins.service.JenkinsBuildService;
 
@@ -30,8 +29,6 @@ public class DetectFreestyleCommands {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             jenkinsBuildService.markBuildInterrupted();
-        } catch (IntegrationException e) {
-            jenkinsBuildService.markBuildUnstable(e);
         } catch (Exception e) {
             jenkinsBuildService.markBuildFailed(e);
         }

--- a/src/test/java/com/synopsys/integration/jenkins/detect/DetectFreestyleCommandsTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/DetectFreestyleCommandsTest.java
@@ -76,12 +76,12 @@ public class DetectFreestyleCommandsTest {
         DetectFreestyleCommands detectCommands = new DetectFreestyleCommands(mockedBuildService, mockedDetectRunner);
         detectCommands.runDetect(StringUtils.EMPTY, DOWNLOAD_STRATEGY);
 
-        Mockito.verify(mockedBuildService).markBuildUnstable(Mockito.any());
+        Mockito.verify(mockedBuildService).markBuildFailed(Mockito.any(IntegrationException.class));
 
         Mockito.verify(mockedBuildService, Mockito.never()).markBuildAborted();
         Mockito.verify(mockedBuildService, Mockito.never()).markBuildInterrupted();
+        Mockito.verify(mockedBuildService, Mockito.never()).markBuildUnstable(Mockito.any());
         Mockito.verify(mockedBuildService, Mockito.never()).markBuildFailed(Mockito.any(String.class));
-        Mockito.verify(mockedBuildService, Mockito.never()).markBuildFailed(Mockito.any(Exception.class));
     }
 
     @Test
@@ -114,7 +114,7 @@ public class DetectFreestyleCommandsTest {
         DetectFreestyleCommands detectCommands = new DetectFreestyleCommands(mockedBuildService, mockedDetectRunner);
         detectCommands.runDetect(StringUtils.EMPTY, DOWNLOAD_STRATEGY);
 
-        Mockito.verify(mockedBuildService).markBuildFailed(Mockito.any(Exception.class));
+        Mockito.verify(mockedBuildService).markBuildFailed(Mockito.any(IOException.class));
 
         Mockito.verify(mockedBuildService, Mockito.never()).markBuildAborted();
         Mockito.verify(mockedBuildService, Mockito.never()).markBuildInterrupted();


### PR DESCRIPTION
Spoke with PM and confirmed we should not be handling IntegrationException's different than other types of Exceptions unless it is a InterruptedException, which should be marked as Interrupted.