### PR TITLE
IDTCTJNKNS-228: Allow to use DETECT_JAVA_PATH and JAVA_HOME

### DIFF
--- a/src/main/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectAirGapJarStrategy.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectAirGapJarStrategy.java
@@ -35,7 +35,13 @@ public class DetectAirGapJarStrategy extends DetectExecutionStrategy {
     private final JenkinsConfigService jenkinsConfigService;
     private final AirGapDownloadStrategy airGapDownloadStrategy;
 
-    public DetectAirGapJarStrategy(JenkinsIntLogger logger, IntEnvironmentVariables intEnvironmentVariables, String remoteJdkHome, JenkinsConfigService jenkinsConfigService, AirGapDownloadStrategy airGapDownloadStrategy) {
+    public DetectAirGapJarStrategy(
+        JenkinsIntLogger logger,
+        IntEnvironmentVariables intEnvironmentVariables,
+        String remoteJdkHome,
+        JenkinsConfigService jenkinsConfigService,
+        AirGapDownloadStrategy airGapDownloadStrategy
+    ) {
         this.logger = logger;
         this.intEnvironmentVariables = intEnvironmentVariables;
         this.remoteJdkHome = remoteJdkHome;
@@ -54,7 +60,10 @@ public class DetectAirGapJarStrategy extends DetectExecutionStrategy {
             String airGapInstallationName = airGapDownloadStrategy.getAirGapInstallationName();
             airGapInstallation = jenkinsConfigService.getInstallationForNodeAndEnvironment(DetectAirGapInstallation.DescriptorImpl.class, airGapInstallationName).orElseThrow(
                 () -> new DetectJenkinsException(
-                    String.format("Problem encountered getting Detect Air Gap tool with the name %s from global tool configuration. Check Jenkins plugin and tool configuration.", airGapInstallationName)));
+                    String.format(
+                        "Problem encountered getting Detect Air Gap tool with the name %s from global tool configuration. Check Jenkins plugin and tool configuration.",
+                        airGapInstallationName
+                    )));
         } catch (IOException e) {
             throw new DetectJenkinsException("Problem encountered while interacting with Jenkins environment. Check Jenkins and environment.", e);
         } catch (InterruptedException e) {
@@ -95,7 +104,7 @@ public class DetectAirGapJarStrategy extends DetectExecutionStrategy {
         public ArrayList<String> call() throws DetectJenkinsException {
             String airGapJar = getAirGapJar(airGapBaseDir);
             RemoteJavaService remoteJavaService = new RemoteJavaService(logger, remoteJdkHome, environmentVariables);
-            String javaExecutablePath = remoteJavaService.calculateJavaExecutablePath();
+            String javaExecutablePath = remoteJavaService.getJavaExecutablePath();
 
             logger.info("Detect AirGap jar configured: " + airGapJar);
 
@@ -107,10 +116,17 @@ public class DetectAirGapJarStrategy extends DetectExecutionStrategy {
             File[] foundAirGapJars = new File(airGapBaseDir).listFiles(fileFilter);
 
             if (foundAirGapJars == null || foundAirGapJars.length == 0) {
-                throw new DetectJenkinsException(String.format("Expected 1 jar from Detect Air Gap tool installation at <%s> and did not find any. Check your Jenkins plugin and tool configuration.", airGapBaseDir));
+                throw new DetectJenkinsException(String.format(
+                    "Expected 1 jar from Detect Air Gap tool installation at <%s> and did not find any. Check your Jenkins plugin and tool configuration.",
+                    airGapBaseDir
+                ));
             } else if (foundAirGapJars.length > 1) {
                 throw new DetectJenkinsException(
-                    String.format("Expected 1 jar from Detect Air Gap tool installation at <%s> and instead found %d jars. Check your Jenkins plugin and tool configuration.", airGapBaseDir, foundAirGapJars.length));
+                    String.format(
+                        "Expected 1 jar from Detect Air Gap tool installation at <%s> and instead found %d jars. Check your Jenkins plugin and tool configuration.",
+                        airGapBaseDir,
+                        foundAirGapJars.length
+                    ));
             } else {
                 return foundAirGapJars[0].toString();
             }

--- a/src/main/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectJarStrategy.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectJarStrategy.java
@@ -58,7 +58,7 @@ public class DetectJarStrategy extends DetectExecutionStrategy {
         @Override
         public ArrayList<String> call() {
             RemoteJavaService remoteJavaService = new RemoteJavaService(logger, remoteJdkHome, environmentVariables);
-            String javaExecutablePath = remoteJavaService.calculateJavaExecutablePath();
+            String javaExecutablePath = remoteJavaService.getJavaExecutablePath();
 
             logger.info("Detect jar configured: " + detectJarPath);
 

--- a/src/test/java/com/synopsys/integration/jenkins/detect/DetectPipelineCommandsTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/DetectPipelineCommandsTest.java
@@ -79,8 +79,7 @@ public class DetectPipelineCommandsTest {
             detectCommands.runDetect(true, StringUtils.EMPTY, DOWNLOAD_STRATEGY);
 
             Mockito.verify(mockedLogger).error(Mockito.anyString());
-        } catch (
-              Exception e) {
+        } catch (Exception e) {
             fail("An unexpected exception occurred in the test code: ", e);
         }
     }

--- a/src/test/java/com/synopsys/integration/jenkins/detect/service/RemoteJavaServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/service/RemoteJavaServiceTest.java
@@ -1,0 +1,106 @@
+package com.synopsys.integration.jenkins.detect.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.synopsys.integration.jenkins.detect.service.strategy.RemoteJavaService;
+import com.synopsys.integration.jenkins.extensions.JenkinsIntLogger;
+import com.synopsys.integration.log.LogLevel;
+import com.synopsys.integration.util.IntEnvironmentVariables;
+
+import hudson.model.TaskListener;
+
+public class RemoteJavaServiceTest {
+
+    private JenkinsIntLogger logger;
+    private ByteArrayOutputStream byteArrayOutputStream;
+
+    @BeforeEach
+    public void setup() {
+        TaskListener taskListener = Mockito.mock(TaskListener.class);
+        byteArrayOutputStream = new ByteArrayOutputStream();
+        Mockito.when(taskListener.getLogger()).thenReturn(new PrintStream(byteArrayOutputStream));
+
+        logger = JenkinsIntLogger.logToListener(taskListener);
+        logger.setLogLevel(LogLevel.DEBUG);
+    }
+
+    @Test
+    public void testRemoteJdkHome() {
+        String remoteJdkHome = "/test/remote/jdk/home";
+        String expectedJavaExecutablePath = remoteJdkHome + "/bin/java";
+
+        IntEnvironmentVariables environmentVariables = IntEnvironmentVariables.empty();
+        RemoteJavaService remoteJavaService = new RemoteJavaService(logger, remoteJdkHome, environmentVariables.getVariables());
+
+        assertEquals(expectedJavaExecutablePath, remoteJavaService.getJavaExecutablePath(), "Could not set Java path by using " + remoteJdkHome);
+        assertTrue(byteArrayOutputStream.toString().contains(expectedJavaExecutablePath), "Log message does not contain correct Java path.");
+        assertTrue(byteArrayOutputStream.toString().contains("Node environment"), "Log message does not contain correct 'based on' message.");
+    }
+
+    @Test
+    public void testDetectJavaPath() {
+        String detectJavaPath = "/test/detect/java/path";
+
+        IntEnvironmentVariables environmentVariables = IntEnvironmentVariables.empty();
+        environmentVariables.put(RemoteJavaService.DETECT_JAVA_PATH, detectJavaPath);
+        RemoteJavaService remoteJavaService = new RemoteJavaService(logger, null, environmentVariables.getVariables());
+
+        assertEquals(detectJavaPath, remoteJavaService.getJavaExecutablePath(), "Could not set Java path by using " + RemoteJavaService.DETECT_JAVA_PATH);
+        assertTrue(byteArrayOutputStream.toString().contains(detectJavaPath), "Log message does not contain correct Java path.");
+        assertTrue(byteArrayOutputStream.toString().contains("DETECT_JAVA_PATH environment variable"), "Log message does not contain correct 'based on' message.");
+    }
+
+    @Test
+    public void testJavaPath() {
+        String javaPath = "/test/java/path";
+        String expectedJavaExecutablePath = javaPath + "/bin/java";
+
+        IntEnvironmentVariables environmentVariables = IntEnvironmentVariables.empty();
+        environmentVariables.put(RemoteJavaService.JAVA_HOME, javaPath);
+        RemoteJavaService remoteJavaService = new RemoteJavaService(logger, null, environmentVariables.getVariables());
+
+        assertEquals(expectedJavaExecutablePath, remoteJavaService.getJavaExecutablePath(), "Could not set Java path by using " + RemoteJavaService.JAVA_HOME);
+        assertTrue(byteArrayOutputStream.toString().contains(expectedJavaExecutablePath), "Log message does not contain correct Java path.");
+        assertTrue(byteArrayOutputStream.toString().contains("JAVA_HOME environment variable"), "Log message does not contain correct 'based on' message.");
+    }
+
+    @Test
+    public void testContainAllOptions() {
+        String remoteJdkHome = "/test/remote/jdk/home";
+        String expectedJavaExecutablePath = remoteJdkHome + "/bin/java";
+        String detectJavaPath = "/test/detect/java/path";
+        String javaPath = "/test/java/path";
+
+        IntEnvironmentVariables environmentVariables = IntEnvironmentVariables.empty();
+        environmentVariables.put(RemoteJavaService.DETECT_JAVA_PATH, detectJavaPath);
+        environmentVariables.put(RemoteJavaService.JAVA_HOME, javaPath);
+        RemoteJavaService remoteJavaService = new RemoteJavaService(logger, remoteJdkHome, environmentVariables.getVariables());
+
+        assertEquals(expectedJavaExecutablePath, remoteJavaService.getJavaExecutablePath(), "Could not set Java path by using " + remoteJdkHome);
+        assertTrue(byteArrayOutputStream.toString().contains(expectedJavaExecutablePath), "Log message does not contain correct Java path.");
+        assertTrue(byteArrayOutputStream.toString().contains("Node environment"), "Log message does not contain correct 'based on' message.");
+    }
+
+    @Test
+    public void testContainBothEnvVars() {
+        String detectJavaPath = "/test/detect/java/path";
+        String javaPath = "/test/java/path";
+
+        IntEnvironmentVariables environmentVariables = IntEnvironmentVariables.empty();
+        environmentVariables.put(RemoteJavaService.DETECT_JAVA_PATH, detectJavaPath);
+        environmentVariables.put(RemoteJavaService.JAVA_HOME, javaPath);
+        RemoteJavaService remoteJavaService = new RemoteJavaService(logger, null, environmentVariables.getVariables());
+
+        assertEquals(detectJavaPath, remoteJavaService.getJavaExecutablePath(), "Could not set Java path by using " + RemoteJavaService.DETECT_JAVA_PATH);
+        assertTrue(byteArrayOutputStream.toString().contains(detectJavaPath), "Log message does not contain correct Java path.");
+        assertTrue(byteArrayOutputStream.toString().contains("DETECT_JAVA_PATH environment variable"), "Log message does not contain correct 'based on' message.");
+    }
+}

--- a/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectAirGapJarStrategyTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectAirGapJarStrategyTest.java
@@ -143,7 +143,7 @@ public class DetectAirGapJarStrategyTest {
             String expectedBadJavaPath = badJavaHome + REMOTE_JAVA_RELATIVE_PATH;
             executeAndValidateSetupCallable(badJavaHome, expectedBadJavaPath, tempJarDirectoryPathName, tempAirGapJar);
 
-            assertTrue(byteArrayOutputStream.toString().contains("Error starting process to get Java version: "), "Log does not contain error for starting process.");
+            assertTrue(byteArrayOutputStream.toString().contains("No such file or directory"), "Log does not contain error for starting process.");
         } catch (IOException e) {
             fail("Unexpected exception was thrown in test code: ", e);
         }

--- a/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectJarStrategyTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectJarStrategyTest.java
@@ -81,7 +81,10 @@ public class DetectJarStrategyTest {
     @Test
     public void testSetupCallableInvalidJdkHome() {
         this.executeAndValidateSetupCallable("\u0000", "java");
-        assertTrue(byteArrayOutputStream.toString().contains("Detect could not get Java Home from configured JDK,"), "Log does not contain message from IOException.");
+        assertTrue(
+            byteArrayOutputStream.toString().contains("Could not set path to Java executable, falling back to PATH."),
+            "Log does not contain message from IOException."
+        );
         this.validateLogsPresentInfo();
     }
 
@@ -125,7 +128,7 @@ public class DetectJarStrategyTest {
             String expectedBadJavaPath = badJavaHome + REMOTE_JAVA_RELATIVE_PATH;
             this.executeAndValidateSetupCallable(badJavaHome, expectedBadJavaPath);
 
-            assertTrue(byteArrayOutputStream.toString().contains("Error starting process to get Java version: "), "Log does not contain error for starting process.");
+            assertTrue(byteArrayOutputStream.toString().contains("No such file or directory"), "Log does not contain error for starting process.");
         } catch (IOException e) {
             fail("Unexpected exception was thrown in test code: ", e);
         }


### PR DESCRIPTION
If not using the Detect script, and java was not on your path, execution of Detect jar would fail, even if JAVA_HOME was set.

Enhance plugin to function as the Detect script does:
* If DETECT_JAVA_PATH is set in environment, use it
* If JAVA_HOME is set in environment, use it
* If neither is set, fall back to assuming java is on PATH

It should be noted, that if DETECT_JAVA_PATH is set, JAVA_HOME is not set, and Java is not on your path, some detectors (Gradle for example) will fail.