### PR TITLE
Dev/jppetrakis/master/working branch for jenkins upgrade  upgrade jpi version used and jenkins core version used.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,16 +42,20 @@ dependencies {
     implementation 'com.synopsys.integration:jenkins-common:0.5.3'
     implementation 'org.jvnet.localizer:localizer:1.31'
 
-    jenkinsPlugins 'org.jenkins-ci.plugins:credentials:2.6.1.1'
-    jenkinsPlugins 'org.jenkins-ci.plugins:plain-credentials:1.7'
+    //jenkinsPlugins 'org.jenkins-ci.plugins:credentials:1139.veb_9579fca_33b_'
+    jenkinsPlugins 'org.jenkins-ci.plugins:credentials:1087.1089.v2f1b_9a_b_040e4'
+    jenkinsPlugins 'org.jenkins-ci.plugins:plain-credentials:139.ved2b_9cf7587b'
 
-    optionalJenkinsPlugins 'org.jenkins-ci.plugins:job-dsl:1.78.1'
-    optionalJenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-job:2.39'
-    optionalJenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-cps:2.94.4'
-    optionalJenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-step-api:2.22'
+    optionalJenkinsPlugins 'org.jenkins-ci.plugins:job-dsl:1.81'
+    //optionalJenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-job:1232.v5a_4c994312f1'
+    optionalJenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-job:1189.va_d37a_e9e4eda_'
+    //optionalJenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-cps:2759.v87459c4eea_ca_'
+    optionalJenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-cps:2729.2732.vda_e3f07b_5a_f8'
+    optionalJenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-step-api:639.v6eca_cd8c04a_a_'
 
-    testCompile group: 'org.jenkins-ci.main', name: 'jenkins-test-harness', version: '2.65'
-    testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.6.2'
-    testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: '5.6.2'
-    testCompile group: 'org.mockito', name: 'mockito-core', version: '2.23.4'
+    testImplementation group: 'org.jenkins-ci.main', name: 'jenkins-test-harness', version: '1816.v8138d8056949'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.6.2'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: '5.6.2'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '2.23.4'
+
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,8 @@ buildscript {
 }
 
 plugins {
-    id 'org.jenkins-ci.jpi' version '0.38.0'
+    //This jpi version is the minimum to eliminate a transitive dep. on vulnerable apache common libs
+    id 'org.jenkins-ci.jpi' version '0.43.0'
 }
 
 project.ext.excludesFromTestCoverage = ['**/DetectDownloadStrategy.java', '**/DetectPipelineStep.java', '**/DetectPostBuildStep.java', '**/DetectAirGapInstallation.java']
@@ -25,8 +26,9 @@ artifactory {
     }
 }
 
+// coreVersion with jpi 0.39.0 and up is now jenkinsVersion --- or CRASH!
 jenkinsPlugin {
-    coreVersion = '2.334'
+    jenkinsVersion = '2.334'
     displayName = 'Synopsys Detect plugin'
     compatibleSinceVersion = '8.0.0'
     url = 'https://wiki.jenkins.io/display/JENKINS/Synopsys+Detect+Plugin'
@@ -38,20 +40,23 @@ jenkinsPlugin {
 dependencies {
     annotationProcessor 'com.synopsys.integration:jenkins-annotation-processor:0.0.5'
 
-    implementation 'com.synopsys.integration:blackduck-common:66.0.2'
-    implementation 'com.synopsys.integration:jenkins-common:0.5.3'
+    implementation 'com.synopsys.integration:blackduck-common:66.1.2'
+    implementation 'com.synopsys.integration:jenkins-common:0.5.4'
     implementation 'org.jvnet.localizer:localizer:1.31'
 
-    //jenkinsPlugins 'org.jenkins-ci.plugins:credentials:1139.veb_9579fca_33b_'
-    jenkinsPlugins 'org.jenkins-ci.plugins:credentials:1087.1089.v2f1b_9a_b_040e4'
-    jenkinsPlugins 'org.jenkins-ci.plugins:plain-credentials:139.ved2b_9cf7587b'
+	// with the more recent jpi plugins, jenkinsPlugins -> implementation
+	//                           optionalJenkinsPlugins -> runtimeOnly (?)
+	//                                      testCompile -> testImplementation
+    implementation 'org.jenkins-ci.plugins:credentials:1087.1089.v2f1b_9a_b_040e4'
+    implementation 'org.jenkins-ci.plugins:plain-credentials:139.ved2b_9cf7587b'
 
-    optionalJenkinsPlugins 'org.jenkins-ci.plugins:job-dsl:1.81'
-    //optionalJenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-job:1232.v5a_4c994312f1'
-    optionalJenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-job:1189.va_d37a_e9e4eda_'
-    //optionalJenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-cps:2759.v87459c4eea_ca_'
-    optionalJenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-cps:2729.2732.vda_e3f07b_5a_f8'
-    optionalJenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-step-api:639.v6eca_cd8c04a_a_'
+    runtimeOnly 'org.jenkins-ci.plugins:job-dsl:1.81'
+
+    // This one *needs* to be implementation or no build
+    implementation 'org.jenkins-ci.plugins.workflow:workflow-job:1189.va_d37a_e9e4eda_'
+    
+    runtimeOnly 'org.jenkins-ci.plugins.workflow:workflow-cps:2729.2732.vda_e3f07b_5a_f8'
+    runtimeOnly 'org.jenkins-ci.plugins.workflow:workflow-step-api:639.v6eca_cd8c04a_a_'
 
     testImplementation group: 'org.jenkins-ci.main', name: 'jenkins-test-harness', version: '1816.v8138d8056949'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.6.2'

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ artifactory {
 }
 
 jenkinsPlugin {
-    coreVersion = '2.248'
+    coreVersion = '2.334'
     displayName = 'Synopsys Detect plugin'
     compatibleSinceVersion = '8.0.0'
     url = 'https://wiki.jenkins.io/display/JENKINS/Synopsys+Detect+Plugin'
@@ -42,12 +42,12 @@ dependencies {
     implementation 'com.synopsys.integration:jenkins-common:0.5.3'
     implementation 'org.jvnet.localizer:localizer:1.31'
 
-    jenkinsPlugins 'org.jenkins-ci.plugins:credentials:2.3.12'
+    jenkinsPlugins 'org.jenkins-ci.plugins:credentials:2.6.1.1'
     jenkinsPlugins 'org.jenkins-ci.plugins:plain-credentials:1.7'
 
-    optionalJenkinsPlugins 'org.jenkins-ci.plugins:job-dsl:1.77'
+    optionalJenkinsPlugins 'org.jenkins-ci.plugins:job-dsl:1.78.1'
     optionalJenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-job:2.39'
-    optionalJenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-cps:2.81'
+    optionalJenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-cps:2.94.4'
     optionalJenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-step-api:2.22'
 
     testCompile group: 'org.jenkins-ci.main', name: 'jenkins-test-harness', version: '2.65'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Purpose:
Address https://jira-sig.internal.synopsys.com/browse/IDTCTJNKNS-258

This is dependent upon PR: https://github.com/synopsys-sig/jenkins-common/pull/33
No source code changes, existing tests are sufficient.

As with pull request 33, changes made to build.gradle to address known security vulnerabilities exposed by earlier versions of jenkins-jpi, jenkins-core and other jenkins supporting plugins.   The following versions are proposed:

jenkins-jpi v 0.43.0
jenkins-core 2.334 (matching in jenkins-common)

The jenkins jpi version requires an upgrade for gradle from 5.2 to 6.x (6.3 chosen).
This upgrade ALSO changes certain keywords used in the gradle file,  most notably:

coreVersion -> jenkinsVersion
jenkinsPlugins -> implementation
testCompile -> testImplementaion
optionalJenkinsPlugins -> runtimeOnly (this is still under study, however).  This particular change does not seem to be as clearly documented as to what the required change from "optionalJenkinsPlugins" should be.

 


<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
