### PR TITLE
Upgrade of gradle-jpi plugin, jenkins version and supporting libs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,25 @@ buildscript {
 }
 
 plugins {
-    id 'org.jenkins-ci.jpi' version '0.38.0'
+    // this version (0.43.0 and up) , uses a later version of test-harness eliminating the 
+    // dependency on a compromised version of apache commons-text.  Shows as a red-herring in scans
+    id 'org.jenkins-ci.jpi' version '0.46.0'
+}
+
+java {
+    registerFeature('workflowJob') {
+        usingSourceSet(sourceSets.main)
+    }
+    registerFeature('workflowJobDsl') {
+        usingSourceSet(sourceSets.main)
+    }
+    registerFeature('workflowCps') {
+        usingSourceSet(sourceSets.main)
+    }
+    registerFeature('workflowStepApi') {
+        usingSourceSet(sourceSets.main)
+    }
+    
 }
 
 project.ext.excludesFromTestCoverage = ['**/DetectDownloadStrategy.java', '**/DetectPipelineStep.java', '**/DetectPostBuildStep.java', '**/DetectAirGapInstallation.java']
@@ -26,7 +44,9 @@ artifactory {
 }
 
 jenkinsPlugin {
-    coreVersion = '2.248'
+    //coreVersion = '2.377' // as of version 0.40.0 of jpi, it's jenkinsVersion...
+    //jenkinsVersion = '2.377' // as of version 0.40.0 of jpi, it's jenkinsVersion...
+    jenkinsVersion = '2.359'
     displayName = 'Synopsys Detect plugin'
     compatibleSinceVersion = '8.0.0'
     url = 'https://wiki.jenkins.io/display/JENKINS/Synopsys+Detect+Plugin'
@@ -36,22 +56,22 @@ jenkinsPlugin {
 }
 
 dependencies {
-    annotationProcessor 'com.synopsys.integration:jenkins-annotation-processor:0.0.5'
+    annotationProcessor 'com.synopsys.integration:jenkins-annotation-processor:0.0.6'
 
-    implementation 'com.synopsys.integration:blackduck-common:66.0.2'
-    implementation 'com.synopsys.integration:jenkins-common:0.5.3'
+    implementation 'com.synopsys.integration:blackduck-common:66.1.2'
+    implementation 'com.synopsys.integration:jenkins-common:0.5.4'
     implementation 'org.jvnet.localizer:localizer:1.31'
 
-    jenkinsPlugins 'org.jenkins-ci.plugins:credentials:2.3.12'
-    jenkinsPlugins 'org.jenkins-ci.plugins:plain-credentials:1.7'
+    implementation 'org.jenkins-ci.plugins:credentials:1139.veb_9579fca_33b_'
+    implementation 'org.jenkins-ci.plugins:plain-credentials:1.8'
 
-    optionalJenkinsPlugins 'org.jenkins-ci.plugins:job-dsl:1.77'
-    optionalJenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-job:2.39'
-    optionalJenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-cps:2.81'
-    optionalJenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-step-api:2.22'
+    workflowJobDslApi 'org.jenkins-ci.plugins:job-dsl:1.80'
+    workflowJobApi 'org.jenkins-ci.plugins.workflow:workflow-job:1203.v7b_7023424efe'
+    workflowCpsApi 'org.jenkins-ci.plugins.workflow:workflow-cps:2729.2732.vda_e3f07b_5a_f8'
+    workflowStepApiApi 'org.jenkins-ci.plugins.workflow:workflow-step-api:622.vb_8e7c15b_c95a_'
 
-    testCompile group: 'org.jenkins-ci.main', name: 'jenkins-test-harness', version: '2.65'
-    testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.6.2'
-    testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: '5.6.2'
-    testCompile group: 'org.mockito', name: 'mockito-core', version: '2.23.4'
+    testImplementation group: 'org.jenkins-ci.main', name: 'jenkins-test-harness', version: '1812.v6d4e97d91fd8'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.6.2'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: '5.6.2'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '2.23.4'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-all.zip

--- a/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectArgumentService.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectArgumentService.java
@@ -103,7 +103,8 @@ public class DetectArgumentService {
         String cleanedArg = argument;
         if (argument.startsWith("--") && argument.contains("=")) {
             String[] splitArgument = argument.split("=", 2);
-            String endArg = splitArgument[1].endsWith("==") ? splitArgument[1] : escaper.apply(splitArgument[1]);
+            //The api token should not be escaped... if it contains "=" or "==" padding, it would cause probs.
+            String endArg = splitArgument[0].contains("blackduck.api.token") ? splitArgument[1] : escaper.apply(splitArgument[1]);
             cleanedArg = splitArgument[0] + "=" + endArg;
         }
 

--- a/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectArgumentService.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectArgumentService.java
@@ -103,7 +103,8 @@ public class DetectArgumentService {
         String cleanedArg = argument;
         if (argument.startsWith("--") && argument.contains("=")) {
             String[] splitArgument = argument.split("=", 2);
-            cleanedArg = splitArgument[0] + "=" + escaper.apply(splitArgument[1]);
+            String endArg = splitArgument[1].endsWith("==") ? splitArgument[1] : escaper.apply(splitArgument[1]);
+            cleanedArg = splitArgument[0] + "=" + endArg;
         }
 
         return cleanedArg;


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Dependent upon: https://github.com/synopsys-sig/jenkins-common/pull/34

As with pull request 33, changes made to build.gradle to address known security vulnerabilities exposed by earlier versions of jenkins-jpi, jenkins-core and other jenkins supporting plugins. The following versions are proposed:

jenkins-jpi v 0.43.0
jenkins-core 2.334 (matching in jenkins-common)

The jenkins jpi version requires an upgrade for gradle from 5.2 to 6.x (6.3 chosen).
This upgrade ALSO changes certain keywords used in the gradle file, most notably:

coreVersion -> jenkinsVersion
jenkinsPlugins -> implementation
testCompile -> testImplementaion
optionalJenkinsPlugins -> Corrected to reflect PROPER optional dependency.  Behavior should be on par with original form.