### PR TITLE
Fix to allow --detect.excluded.directories to work correctly again with wildcards like v7

### DIFF
--- a/src/main/java/com/synopsys/integration/IntegrationEscapeUtils.java
+++ b/src/main/java/com/synopsys/integration/IntegrationEscapeUtils.java
@@ -18,6 +18,9 @@ import org.apache.commons.text.translate.LookupTranslator;
 public class IntegrationEscapeUtils extends StringEscapeUtils {
     public static final CharSequenceTranslator ESCAPE_POWERSHELL;
 
+    // same as ESCAPE_XSI without escaping Asterisk '*' so wildcards for excluding directories work again like v7
+    public static final CharSequenceTranslator ESCAPE_XSI_MINUS_A;
+
     static {
         Map<CharSequence, CharSequence> escapePowershellMap = new HashMap<>();
         escapePowershellMap.put("|", "`|");
@@ -36,7 +39,6 @@ public class IntegrationEscapeUtils extends StringEscapeUtils {
         escapePowershellMap.put("\t", "`\t");
         escapePowershellMap.put("\r\n", "");
         escapePowershellMap.put("\n", "");
-        escapePowershellMap.put("*", "`*");
         escapePowershellMap.put("?", "`?");
         escapePowershellMap.put("[", "`[");
         escapePowershellMap.put("#", "`#");
@@ -49,7 +51,38 @@ public class IntegrationEscapeUtils extends StringEscapeUtils {
         );
     }
 
+    static {
+        Map<CharSequence, CharSequence> unescapeJavaMap = new HashMap<>();
+        unescapeJavaMap.put("|", "\\|");
+        unescapeJavaMap.put("&", "\\&");
+        unescapeJavaMap.put(";", "\\;");
+        unescapeJavaMap.put("<", "\\<");
+        unescapeJavaMap.put(">", "\\>");
+        unescapeJavaMap.put("(", "\\(");
+        unescapeJavaMap.put(")", "\\)");
+        unescapeJavaMap.put("$", "\\$");
+        unescapeJavaMap.put("`", "\\`");
+        unescapeJavaMap.put("\\", "\\\\");
+        unescapeJavaMap.put("\"", "\\\"");
+        unescapeJavaMap.put("'", "\\'");
+        unescapeJavaMap.put(" ", "\\ ");
+        unescapeJavaMap.put("\t", "\\\t");
+        unescapeJavaMap.put("\r\n", "");
+        unescapeJavaMap.put("\n", "");
+        unescapeJavaMap.put("?", "\\?");
+        unescapeJavaMap.put("[", "\\[");
+        unescapeJavaMap.put("#", "\\#");
+        unescapeJavaMap.put("~", "\\~");
+        unescapeJavaMap.put("=", "\\=");
+        unescapeJavaMap.put("%", "\\%");
+        ESCAPE_XSI_MINUS_A = new LookupTranslator(Collections.unmodifiableMap(unescapeJavaMap));
+    }
+
     public static String escapePowerShell(String input) {
         return ESCAPE_POWERSHELL.translate(input);
+    }
+
+    public static String escapeXSIMinusAsterisk(String input) {
+        return ESCAPE_XSI_MINUS_A.translate(input);
     }
 }

--- a/src/main/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectScriptStrategy.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectScriptStrategy.java
@@ -57,7 +57,7 @@ public class DetectScriptStrategy extends DetectExecutionStrategy {
         if (operatingSystemType == OperatingSystemType.WINDOWS) {
             return IntegrationEscapeUtils::escapePowerShell;
         }
-        return IntegrationEscapeUtils::escapeXSI;
+        return IntegrationEscapeUtils::escapeXSIMinusAsterisk;
     }
 
     @Override

--- a/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectScriptStrategyTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/detect/service/strategy/DetectScriptStrategyTest.java
@@ -53,7 +53,7 @@ public class DetectScriptStrategyTest {
     @Test
     public void testArgumentEscaperLinux() {
         DetectScriptStrategy detectScriptStrategy = new DetectScriptStrategy(defaultLogger, defaultProxyHelper, OperatingSystemType.LINUX, null);
-        String expectedEscapedString = "\\|\\&\\;\\<\\>\\(\\)\\$\\`\\\\\\\"\\'\\ \\\t\\*\\?\\[\\#\\~\\=\\%,";
+        String expectedEscapedString = "\\|\\&\\;\\<\\>\\(\\)\\$\\`\\\\\\\"\\'\\ \\\t*\\?\\[\\#\\~\\=\\%,";
 
         String escapedString = detectScriptStrategy.getArgumentEscaper().apply(unescapedSpecialCharacters);
 
@@ -63,7 +63,7 @@ public class DetectScriptStrategyTest {
     @Test
     public void testArgumentEscaperMac() {
         DetectScriptStrategy detectScriptStrategy = new DetectScriptStrategy(defaultLogger, defaultProxyHelper, OperatingSystemType.MAC, null);
-        String expectedEscapedString = "\\|\\&\\;\\<\\>\\(\\)\\$\\`\\\\\\\"\\'\\ \\\t\\*\\?\\[\\#\\~\\=\\%,";
+        String expectedEscapedString = "\\|\\&\\;\\<\\>\\(\\)\\$\\`\\\\\\\"\\'\\ \\\t*\\?\\[\\#\\~\\=\\%,";
 
         String escapedString = detectScriptStrategy.getArgumentEscaper().apply(unescapedSpecialCharacters);
 
@@ -73,7 +73,7 @@ public class DetectScriptStrategyTest {
     @Test
     public void testArgumentEscaperWindows() {
         DetectScriptStrategy detectScriptStrategy = new DetectScriptStrategy(defaultLogger, defaultProxyHelper, OperatingSystemType.WINDOWS, null);
-        String expectedEscapedString = "`|`&`;`<`>`(`)`$```\\`\"`'` `\t`*`?`[`#`~`=`%`,";
+        String expectedEscapedString = "`|`&`;`<`>`(`)`$```\\`\"`'` `\t*`?`[`#`~`=`%`,";
 
         String escapedString = detectScriptStrategy.getArgumentEscaper().apply(unescapedSpecialCharacters);
 


### PR DESCRIPTION
Don't escape asterisk '*' in DetectScriptStrategy so wildcards can correctly work again for `--detect.excluded.directories`
See [https://community.synopsys.com/s/article/detect-excluded-directories-doesn-t-work](url) 

The workaround wasn't an option for us as unfortunately our repo is messy and there are about 100 directories that need to be excluded. Using a static list would be unmaintainable in our situation.

### Testing done

Updated the existing DetectScriptStrategyTest to verify that '*' are not escaped, and tested this then allows the `--detect.excluded.directories` option to work correctly in our Jenkins builds (it does). **Note:** however we build with Linux so powershell was not tested in Jenkins.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
