### PR TITLE
Fix error that introduced extra '\' before '&' in detect arguments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,13 @@ dependencies {
     annotationProcessor 'com.synopsys.integration:jenkins-annotation-processor:0.0.7'
 
     implementation 'com.synopsys.integration:blackduck-common:66.1.2'
-    implementation 'com.synopsys.integration:jenkins-common:0.5.5'
+    implementation ('com.synopsys.integration:jenkins-common:0.5.5') {
+        exclude group: "org.jenkins-ci.main", module: "jenkins-core"
+        exclude group: "org.jenkins-ci.plugins", module: "credentials"
+        exclude group: "org.jenkins-ci.plugins", module: "plain-credentials"
+        exclude group: "org.jenkins-ci.plugins.workflow", module: "workflow-support"
+        exclude group: "org.jenkins-ci.plugins.workflow", module: "workflow-api"
+    }
     implementation 'org.jvnet.localizer:localizer:1.31'
 
     implementation 'org.jenkins-ci.plugins:credentials:1139.veb_9579fca_33b_'

--- a/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectArgumentService.java
+++ b/src/main/java/com/synopsys/integration/jenkins/detect/service/DetectArgumentService.java
@@ -101,7 +101,7 @@ public class DetectArgumentService {
     private String escapeArgument(String argument, Function<String, String> escaper) {
         // Assume a cleaned argument, then test
         String cleanedArg = argument;
-        if (argument.startsWith("--") && argument.contains("=")) {
+        if (argument.startsWith("--") && argument.contains("=") && !argument.contains("&")) {
             String[] splitArgument = argument.split("=", 2);
             //The api token should not be escaped... if it contains "=" or "==" padding, it would cause probs.
             String endArg = splitArgument[0].contains("blackduck.api.token") ? splitArgument[1] : escaper.apply(splitArgument[1]);


### PR DESCRIPTION
This issue fixes an error that introduced extra '\' that appears before '&' as described in the ticket attached IDTCTJNKNS-272. The solution will not escape arguments that contain an '&' and keep the string as it is. The problem was that detect was detect was already quoting this arguments in single quotes and the introduced '\'  while escaping was also stacked into the path.

Eg. echo 'path&' -> path&
      echo 'path\&' -> path\& 

The other issue was already fixed in 8.0.z branch but not rebased into master so I added this change here.


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```